### PR TITLE
Range-based cilk_for (DRAFT)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -54,7 +54,3 @@ autoconf/autom4te.cache
 .vs
 # clangd index
 .clangd
-
-
-cheetah/*
-

--- a/.gitignore
+++ b/.gitignore
@@ -54,3 +54,7 @@ autoconf/autom4te.cache
 .vs
 # clangd index
 .clangd
+
+
+cheetah/*
+

--- a/clang/include/clang-c/Index.h
+++ b/clang/include/clang-c/Index.h
@@ -2590,7 +2590,11 @@ enum CXCursorKind {
    */
   CXCursor_CilkForStmt                   = 289,
 
-  CXCursor_LastStmt = CXCursor_CilkForStmt,
+  /** A _Cilk_for range statement.
+   */
+  CXCursor_CilkForRangeStmt                   = 290,
+
+  CXCursor_LastStmt = CXCursor_CilkForRangeStmt,
 
   /**
    * Cursor that represents the translation unit itself.

--- a/clang/include/clang/AST/RecursiveASTVisitor.h
+++ b/clang/include/clang/AST/RecursiveASTVisitor.h
@@ -2669,6 +2669,7 @@ DEF_TRAVERSE_STMT(CilkSpawnStmt, {})
 DEF_TRAVERSE_STMT(CilkSpawnExpr, {})
 DEF_TRAVERSE_STMT(CilkSyncStmt, {})
 DEF_TRAVERSE_STMT(CilkForStmt, {})
+DEF_TRAVERSE_STMT(CilkForRangeStmt, {})
 
 // These operators (all of them) do not need any action except
 // iterating over the children.

--- a/clang/include/clang/AST/StmtCilk.h
+++ b/clang/include/clang/AST/StmtCilk.h
@@ -86,11 +86,11 @@ public:
 };
 
 class CilkForRangeStmt : public Stmt {
-  enum { FORRANGE, LOOPINDEX, COND, END };
+  enum { FORRANGE, LOOPINDEX, COND, INC, END };
   Stmt* SubExprs[END];
 
 public:
-  CilkForRangeStmt(const ASTContext &C, CXXForRangeStmt *ForRange, VarDecl *LoopIndex, Expr *Cond);
+  CilkForRangeStmt(const ASTContext &C, CXXForRangeStmt *ForRange, VarDecl *LoopIndex, Expr *Cond, Expr *Inc);
 
   /// \brief Build an empty for range statement.
   explicit CilkForRangeStmt(EmptyShell Empty) : Stmt(CilkForRangeStmtClass, Empty) { }

--- a/clang/include/clang/AST/StmtCilk.h
+++ b/clang/include/clang/AST/StmtCilk.h
@@ -104,10 +104,8 @@ public:
 
   void setForRange(Stmt *S) { SubExprs[FORRANGE] = S; }
 
-  SourceLocation getBeginLoc() const LLVM_READONLY { return getCXXForRangeStmt()->getBeginLoc(); }
-  SourceLocation getEndLoc() const LLVM_READONLY {
-    return getCXXForRangeStmt()->getEndLoc();
-  }
+  SourceLocation getBeginLoc() const LLVM_READONLY;
+  SourceLocation getEndLoc() const LLVM_READONLY;
 
 };
 

--- a/clang/include/clang/AST/StmtCilk.h
+++ b/clang/include/clang/AST/StmtCilk.h
@@ -90,7 +90,7 @@ class CilkForRangeStmt : public Stmt {
   Stmt* SubExprs[END];
 
 public:
-  CilkForRangeStmt(const ASTContext &C, CXXForRangeStmt *ForRange, VarDecl *LoopVar);
+  CilkForRangeStmt(const ASTContext &C, CXXForRangeStmt *ForRange, VarDecl *LoopVar, Expr *Cond);
 
   /// \brief Build an empty for range statement.
   explicit CilkForRangeStmt(EmptyShell Empty) : Stmt(CilkForRangeStmtClass, Empty) { }

--- a/clang/include/clang/AST/StmtCilk.h
+++ b/clang/include/clang/AST/StmtCilk.h
@@ -101,7 +101,7 @@ public:
                    VarDecl *LoopIndex, DeclStmt *Limit, Expr *Cond, Expr *Inc,
                    DeclStmt *LoopIndexStmt);
 
-  /// \brief Build an empty for range statement.
+  /// \brief Build an empty cilk for range statement.
   explicit CilkForRangeStmt(EmptyShell Empty)
       : Stmt(CilkForRangeStmtClass, Empty) {}
 
@@ -113,14 +113,14 @@ public:
 
   void setForRange(Stmt *S) { SubExprs[FORRANGE] = S; }
 
-  DeclStmt *getLoopIndexStmt() {
-    return cast_or_null<DeclStmt>(SubExprs[LOOPINDEXSTMT]);
-  }
   VarDecl *getLoopIndex() const;
   void setLoopIndex(const ASTContext &C, VarDecl *V);
 
   Expr *getCond() { return reinterpret_cast<Expr *>(SubExprs[COND]); }
   Expr *getInc() { return reinterpret_cast<Expr *>(SubExprs[INC]); }
+  DeclStmt *getLoopIndexStmt() {
+    return cast_or_null<DeclStmt>(SubExprs[LOOPINDEXSTMT]);
+  }
   DeclStmt *getLimitStmt() { return cast_or_null<DeclStmt>(SubExprs[LIMIT]); }
 
   const Expr *getCond() const {

--- a/clang/include/clang/AST/StmtCilk.h
+++ b/clang/include/clang/AST/StmtCilk.h
@@ -86,11 +86,11 @@ public:
 };
 
 class CilkForRangeStmt : public Stmt {
-  enum { FORRANGE, END };
+  enum { FORRANGE, LOOPVAR, COND, END };
   Stmt* SubExprs[END];
 
 public:
-  CilkForRangeStmt(const ASTContext &C, CXXForRangeStmt *ForRange);
+  CilkForRangeStmt(const ASTContext &C, CXXForRangeStmt *ForRange, VarDecl *LoopVar);
 
   /// \brief Build an empty for range statement.
   explicit CilkForRangeStmt(EmptyShell Empty) : Stmt(CilkForRangeStmtClass, Empty) { }
@@ -102,6 +102,9 @@ public:
   CXXForRangeStmt* getCXXForRangeStmt() const;
 
   void setForRange(Stmt *S) { SubExprs[FORRANGE] = S; }
+
+  VarDecl *getLoopVariable() const;
+  void setLoopVariable(const ASTContext &C, VarDecl *V);
 
   SourceLocation getBeginLoc() const LLVM_READONLY;
   SourceLocation getEndLoc() const LLVM_READONLY;

--- a/clang/include/clang/AST/StmtCilk.h
+++ b/clang/include/clang/AST/StmtCilk.h
@@ -98,9 +98,7 @@ public:
     return T->getStmtClass() == CilkForRangeStmtClass;
   }
 
-  CXXForRangeStmt* getCXXForRangeStmt() const {
-    return cast_or_null<CXXForRangeStmt>(SubExprs[FORRANGE]);
-  }
+  CXXForRangeStmt* getCXXForRangeStmt() const;
 
   void setForRange(Stmt *S) { SubExprs[FORRANGE] = S; }
 

--- a/clang/include/clang/AST/StmtCilk.h
+++ b/clang/include/clang/AST/StmtCilk.h
@@ -93,12 +93,12 @@ public:
 /// This is stored as a FORRANGE stmt embedded inside a CILKFORRANGE with some
 /// other necessary semantic components.
 class CilkForRangeStmt : public Stmt {
-  enum { FORRANGE, LOOPINDEX, LOOPINDEXSTMT, LIMIT, COND, INC, END };
+  enum { FORRANGE, LOOPINDEX, LOOPINDEXSTMT, LOCALLOOPINDEX, LIMIT, COND, INC, END };
   Stmt *SubExprs[END];
 
 public:
   CilkForRangeStmt(const ASTContext &C, CXXForRangeStmt *ForRange,
-                   VarDecl *LoopIndex, DeclStmt *Limit, Expr *Cond, Expr *Inc,
+                   VarDecl *LoopIndex, DeclStmt *LocalLoopIndex, DeclStmt *Limit, Expr *Cond, Expr *Inc,
                    DeclStmt *LoopIndexStmt);
 
   /// \brief Build an empty cilk for range statement.
@@ -122,6 +122,7 @@ public:
     return cast_or_null<DeclStmt>(SubExprs[LOOPINDEXSTMT]);
   }
   DeclStmt *getLimitStmt() { return cast_or_null<DeclStmt>(SubExprs[LIMIT]); }
+  DeclStmt *getLocalLoopIndexStmt() { return cast<DeclStmt>(SubExprs[LOCALLOOPINDEX]); }
 
   const Expr *getCond() const {
     return reinterpret_cast<Expr *>(SubExprs[COND]);
@@ -133,6 +134,7 @@ public:
   const DeclStmt *getLimitStmt() const {
     return cast_or_null<DeclStmt>(SubExprs[LIMIT]);
   }
+  const DeclStmt *getLocalLoopIndexStmt() const { return cast<DeclStmt>(SubExprs[LOCALLOOPINDEX]); }
 
   SourceLocation getBeginLoc() const LLVM_READONLY;
   SourceLocation getEndLoc() const LLVM_READONLY;

--- a/clang/include/clang/AST/StmtCilk.h
+++ b/clang/include/clang/AST/StmtCilk.h
@@ -14,6 +14,7 @@
 #define LLVM_CLANG_AST_STMTCILK_H
 
 #include "clang/AST/Stmt.h"
+#include "clang/AST/StmtCXX.h"
 #include "clang/Basic/SourceLocation.h"
 
 namespace clang {
@@ -102,8 +103,13 @@ public:
 
   void setForRange(Stmt *S) { SubExprs[FORRANGE] = S; }
 
-  SourceLocation getBeginLoc() const LLVM_READONLY;
-  SourceLocation getEndLoc() const LLVM_READONLY;
+  SourceLocation getBeginLoc() const;
+  SourceLocation getEndLoc() const;
+
+  // Iterators
+  child_range children() {
+    return child_range(&SubExprs[0], &SubExprs[END]);
+  }
 
 };
 

--- a/clang/include/clang/AST/StmtCilk.h
+++ b/clang/include/clang/AST/StmtCilk.h
@@ -84,6 +84,28 @@ public:
   }
 };
 
+class CilkForRangeStmt : public Stmt {
+  enum { FORRANGE, END };
+  Stmt* SubExprs[END];
+
+public:
+  CilkForRangeStmt(const ASTContext &C, CXXForRangeStmt *ForRange);
+
+  /// \brief Build an empty for range statement.
+  explicit CilkForRangeStmt(EmptyShell Empty) : Stmt(CilkForRangeStmtClass, Empty) { }
+
+  static bool classof(const Stmt *T) {
+    return T->getStmtClass() == CilkForRangeStmtClass;
+  }
+
+  CXXForRangeStmt* getCXXForRangeStmt() {
+    return cast_or_null<CXXForRangeStmt>(SubExprs[FORRANGE]);
+  }
+
+  void setForRange(Stmt *S) { SubExprs[FORRANGE] = S; }
+
+};
+
 /// CilkForStmt - This represents a '_Cilk_for(init;cond;inc)' stmt.
 class CilkForStmt : public Stmt {
   SourceLocation CilkForLoc;

--- a/clang/include/clang/AST/StmtCilk.h
+++ b/clang/include/clang/AST/StmtCilk.h
@@ -93,12 +93,22 @@ public:
 /// This is stored as a FORRANGE stmt embedded inside a CILKFORRANGE with some
 /// other necessary semantic components.
 class CilkForRangeStmt : public Stmt {
-  enum { FORRANGE, LOOPINDEX, LOOPINDEXSTMT, LOCALLOOPINDEX, LIMIT, COND, INC, END };
+  enum {
+    FORRANGE,
+    LOOPINDEX,
+    LOOPINDEXSTMT,
+    LOCALLOOPINDEX,
+    LIMIT,
+    COND,
+    INC,
+    END
+  };
   Stmt *SubExprs[END];
 
 public:
   CilkForRangeStmt(const ASTContext &C, CXXForRangeStmt *ForRange,
-                   VarDecl *LoopIndex, DeclStmt *LocalLoopIndex, DeclStmt *Limit, Expr *Cond, Expr *Inc,
+                   VarDecl *LoopIndex, DeclStmt *LocalLoopIndex,
+                   DeclStmt *Limit, Expr *Cond, Expr *Inc,
                    DeclStmt *LoopIndexStmt);
 
   /// \brief Build an empty cilk for range statement.
@@ -125,7 +135,9 @@ public:
     return cast_or_null<DeclStmt>(SubExprs[LOOPINDEXSTMT]);
   }
   DeclStmt *getLimitStmt() { return cast_or_null<DeclStmt>(SubExprs[LIMIT]); }
-  DeclStmt *getLocalLoopIndexStmt() { return cast<DeclStmt>(SubExprs[LOCALLOOPINDEX]); }
+  DeclStmt *getLocalLoopIndexStmt() {
+    return cast<DeclStmt>(SubExprs[LOCALLOOPINDEX]);
+  }
 
   const Expr *getCond() const {
     return reinterpret_cast<Expr *>(SubExprs[COND]);
@@ -137,7 +149,9 @@ public:
   const DeclStmt *getLimitStmt() const {
     return cast_or_null<DeclStmt>(SubExprs[LIMIT]);
   }
-  const DeclStmt *getLocalLoopIndexStmt() const { return cast<DeclStmt>(SubExprs[LOCALLOOPINDEX]); }
+  const DeclStmt *getLocalLoopIndexStmt() const {
+    return cast<DeclStmt>(SubExprs[LOCALLOOPINDEX]);
+  }
 
   SourceLocation getBeginLoc() const LLVM_READONLY;
   SourceLocation getEndLoc() const LLVM_READONLY;

--- a/clang/include/clang/AST/StmtCilk.h
+++ b/clang/include/clang/AST/StmtCilk.h
@@ -106,6 +106,9 @@ public:
   VarDecl *getLoopIndex() const;
   void setLoopIndex(const ASTContext &C, VarDecl *V);
 
+  Expr *getCond() { return reinterpret_cast<Expr*>(SubExprs[COND]); }
+  Expr *getInc()  { return reinterpret_cast<Expr*>(SubExprs[INC]); }
+
   SourceLocation getBeginLoc() const LLVM_READONLY;
   SourceLocation getEndLoc() const LLVM_READONLY;
 

--- a/clang/include/clang/AST/StmtCilk.h
+++ b/clang/include/clang/AST/StmtCilk.h
@@ -98,11 +98,16 @@ public:
     return T->getStmtClass() == CilkForRangeStmtClass;
   }
 
-  CXXForRangeStmt* getCXXForRangeStmt() {
+  CXXForRangeStmt* getCXXForRangeStmt() const {
     return cast_or_null<CXXForRangeStmt>(SubExprs[FORRANGE]);
   }
 
   void setForRange(Stmt *S) { SubExprs[FORRANGE] = S; }
+
+  SourceLocation getBeginLoc() const LLVM_READONLY { return getCXXForRangeStmt()->getBeginLoc(); }
+  SourceLocation getEndLoc() const LLVM_READONLY {
+    return getCXXForRangeStmt()->getEndLoc();
+  }
 
 };
 

--- a/clang/include/clang/AST/StmtCilk.h
+++ b/clang/include/clang/AST/StmtCilk.h
@@ -112,6 +112,10 @@ public:
   Expr *getCond() { return reinterpret_cast<Expr*>(SubExprs[COND]); }
   Expr *getInc()  { return reinterpret_cast<Expr*>(SubExprs[INC]); }
 
+  const DeclStmt *getLoopIndexStmt() const {
+    return cast_or_null<DeclStmt>(SubExprs[LOOPINDEXSTMT]);
+  }
+
   SourceLocation getBeginLoc() const LLVM_READONLY;
   SourceLocation getEndLoc() const LLVM_READONLY;
 

--- a/clang/include/clang/AST/StmtCilk.h
+++ b/clang/include/clang/AST/StmtCilk.h
@@ -86,12 +86,12 @@ public:
 };
 
 /// CilkForRangeStmt - This represents a '_Cilk_for(range-declarator :
-/// range-expression)' or 'for (init-statement range-declarator :
-/// range-expression)'.) based on a CXXForRangeStmt which is a C++0x
+/// range-expression)' or a '_Cilk_for (init-statement range-declarator :
+/// range-expression)', based on a CXXForRangeStmt which is a C++0x
 /// [stmt.ranged]'s ranged for stmt
 ///
 /// This is stored as a FORRANGE stmt embedded inside a CILKFORRANGE with some
-/// other necessary semantic compenents.
+/// other necessary semantic components.
 class CilkForRangeStmt : public Stmt {
   enum { FORRANGE, LOOPINDEX, LOOPINDEXSTMT, LIMIT, COND, INC, END };
   Stmt *SubExprs[END];

--- a/clang/include/clang/AST/StmtCilk.h
+++ b/clang/include/clang/AST/StmtCilk.h
@@ -86,11 +86,11 @@ public:
 };
 
 class CilkForRangeStmt : public Stmt {
-  enum { FORRANGE, LOOPINDEX, COND, INC, END };
+  enum { FORRANGE, LOOPINDEX, LOOPINDEXSTMT, COND, INC, END };
   Stmt* SubExprs[END];
 
 public:
-  CilkForRangeStmt(const ASTContext &C, CXXForRangeStmt *ForRange, VarDecl *LoopIndex, Expr *Cond, Expr *Inc);
+  CilkForRangeStmt(const ASTContext &C, CXXForRangeStmt *ForRange, VarDecl *LoopIndex, Expr *Cond, Expr *Inc, DeclStmt *LoopIndexStmt);
 
   /// \brief Build an empty for range statement.
   explicit CilkForRangeStmt(EmptyShell Empty) : Stmt(CilkForRangeStmtClass, Empty) { }
@@ -103,6 +103,9 @@ public:
 
   void setForRange(Stmt *S) { SubExprs[FORRANGE] = S; }
 
+  DeclStmt *getLoopIndexStmt() {
+    return cast_or_null<DeclStmt>(SubExprs[LOOPINDEXSTMT]);
+  }
   VarDecl *getLoopIndex() const;
   void setLoopIndex(const ASTContext &C, VarDecl *V);
 

--- a/clang/include/clang/AST/StmtCilk.h
+++ b/clang/include/clang/AST/StmtCilk.h
@@ -116,6 +116,9 @@ public:
   VarDecl *getLoopIndex() const;
   void setLoopIndex(const ASTContext &C, VarDecl *V);
 
+  VarDecl *getLocalLoopIndex();
+  const VarDecl *getLocalLoopIndex() const;
+
   Expr *getCond() { return reinterpret_cast<Expr *>(SubExprs[COND]); }
   Expr *getInc() { return reinterpret_cast<Expr *>(SubExprs[INC]); }
   DeclStmt *getLoopIndexStmt() {

--- a/clang/include/clang/AST/StmtCilk.h
+++ b/clang/include/clang/AST/StmtCilk.h
@@ -86,11 +86,11 @@ public:
 };
 
 class CilkForRangeStmt : public Stmt {
-  enum { FORRANGE, LOOPVAR, COND, END };
+  enum { FORRANGE, LOOPINDEX, COND, END };
   Stmt* SubExprs[END];
 
 public:
-  CilkForRangeStmt(const ASTContext &C, CXXForRangeStmt *ForRange, VarDecl *LoopVar, Expr *Cond);
+  CilkForRangeStmt(const ASTContext &C, CXXForRangeStmt *ForRange, VarDecl *LoopIndex, Expr *Cond);
 
   /// \brief Build an empty for range statement.
   explicit CilkForRangeStmt(EmptyShell Empty) : Stmt(CilkForRangeStmtClass, Empty) { }
@@ -103,8 +103,8 @@ public:
 
   void setForRange(Stmt *S) { SubExprs[FORRANGE] = S; }
 
-  VarDecl *getLoopVariable() const;
-  void setLoopVariable(const ASTContext &C, VarDecl *V);
+  VarDecl *getLoopIndex() const;
+  void setLoopIndex(const ASTContext &C, VarDecl *V);
 
   SourceLocation getBeginLoc() const LLVM_READONLY;
   SourceLocation getEndLoc() const LLVM_READONLY;

--- a/clang/include/clang/AST/StmtCilk.h
+++ b/clang/include/clang/AST/StmtCilk.h
@@ -112,6 +112,8 @@ public:
   Expr *getCond() { return reinterpret_cast<Expr*>(SubExprs[COND]); }
   Expr *getInc()  { return reinterpret_cast<Expr*>(SubExprs[INC]); }
 
+  const Expr *getCond() const { return reinterpret_cast<Expr*>(SubExprs[COND]);}
+  const Expr *getInc()  const { return reinterpret_cast<Expr*>(SubExprs[INC]); }
   const DeclStmt *getLoopIndexStmt() const {
     return cast_or_null<DeclStmt>(SubExprs[LOOPINDEXSTMT]);
   }

--- a/clang/include/clang/AST/StmtCilk.h
+++ b/clang/include/clang/AST/StmtCilk.h
@@ -103,8 +103,8 @@ public:
 
   void setForRange(Stmt *S) { SubExprs[FORRANGE] = S; }
 
-  SourceLocation getBeginLoc() const;
-  SourceLocation getEndLoc() const;
+  SourceLocation getBeginLoc() const LLVM_READONLY;
+  SourceLocation getEndLoc() const LLVM_READONLY;
 
   // Iterators
   child_range children() {

--- a/clang/include/clang/AST/StmtCilk.h
+++ b/clang/include/clang/AST/StmtCilk.h
@@ -85,21 +85,31 @@ public:
   }
 };
 
+/// CilkForRangeStmt - This represents a '_Cilk_for(range-declarator :
+/// range-expression)' or 'for (init-statement range-declarator :
+/// range-expression)'.) based on a CXXForRangeStmt which is a C++0x
+/// [stmt.ranged]'s ranged for stmt
+///
+/// This is stored as a FORRANGE stmt embedded inside a CILKFORRANGE with some
+/// other necessary semantic compenents.
 class CilkForRangeStmt : public Stmt {
   enum { FORRANGE, LOOPINDEX, LOOPINDEXSTMT, LIMIT, COND, INC, END };
-  Stmt* SubExprs[END];
+  Stmt *SubExprs[END];
 
 public:
-  CilkForRangeStmt(const ASTContext &C, CXXForRangeStmt *ForRange, VarDecl *LoopIndex, DeclStmt *Limit, Expr *Cond, Expr *Inc, DeclStmt *LoopIndexStmt);
+  CilkForRangeStmt(const ASTContext &C, CXXForRangeStmt *ForRange,
+                   VarDecl *LoopIndex, DeclStmt *Limit, Expr *Cond, Expr *Inc,
+                   DeclStmt *LoopIndexStmt);
 
   /// \brief Build an empty for range statement.
-  explicit CilkForRangeStmt(EmptyShell Empty) : Stmt(CilkForRangeStmtClass, Empty) { }
+  explicit CilkForRangeStmt(EmptyShell Empty)
+      : Stmt(CilkForRangeStmtClass, Empty) {}
 
   static bool classof(const Stmt *T) {
     return T->getStmtClass() == CilkForRangeStmtClass;
   }
 
-  CXXForRangeStmt* getCXXForRangeStmt() const;
+  CXXForRangeStmt *getCXXForRangeStmt() const;
 
   void setForRange(Stmt *S) { SubExprs[FORRANGE] = S; }
 
@@ -109,14 +119,14 @@ public:
   VarDecl *getLoopIndex() const;
   void setLoopIndex(const ASTContext &C, VarDecl *V);
 
-  Expr *getCond() { return reinterpret_cast<Expr*>(SubExprs[COND]); }
-  Expr *getInc()  { return reinterpret_cast<Expr*>(SubExprs[INC]); }
-  DeclStmt *getLimitStmt() {
-    return cast_or_null<DeclStmt>(SubExprs[LIMIT]);
-  }
+  Expr *getCond() { return reinterpret_cast<Expr *>(SubExprs[COND]); }
+  Expr *getInc() { return reinterpret_cast<Expr *>(SubExprs[INC]); }
+  DeclStmt *getLimitStmt() { return cast_or_null<DeclStmt>(SubExprs[LIMIT]); }
 
-  const Expr *getCond() const { return reinterpret_cast<Expr*>(SubExprs[COND]);}
-  const Expr *getInc()  const { return reinterpret_cast<Expr*>(SubExprs[INC]); }
+  const Expr *getCond() const {
+    return reinterpret_cast<Expr *>(SubExprs[COND]);
+  }
+  const Expr *getInc() const { return reinterpret_cast<Expr *>(SubExprs[INC]); }
   const DeclStmt *getLoopIndexStmt() const {
     return cast_or_null<DeclStmt>(SubExprs[LOOPINDEXSTMT]);
   }
@@ -128,10 +138,7 @@ public:
   SourceLocation getEndLoc() const LLVM_READONLY;
 
   // Iterators
-  child_range children() {
-    return child_range(&SubExprs[0], &SubExprs[END]);
-  }
-
+  child_range children() { return child_range(&SubExprs[0], &SubExprs[END]); }
 };
 
 /// CilkForStmt - This represents a '_Cilk_for(init;cond;inc)' stmt.

--- a/clang/include/clang/AST/StmtCilk.h
+++ b/clang/include/clang/AST/StmtCilk.h
@@ -86,11 +86,11 @@ public:
 };
 
 class CilkForRangeStmt : public Stmt {
-  enum { FORRANGE, LOOPINDEX, LOOPINDEXSTMT, COND, INC, END };
+  enum { FORRANGE, LOOPINDEX, LOOPINDEXSTMT, LIMIT, COND, INC, END };
   Stmt* SubExprs[END];
 
 public:
-  CilkForRangeStmt(const ASTContext &C, CXXForRangeStmt *ForRange, VarDecl *LoopIndex, Expr *Cond, Expr *Inc, DeclStmt *LoopIndexStmt);
+  CilkForRangeStmt(const ASTContext &C, CXXForRangeStmt *ForRange, VarDecl *LoopIndex, DeclStmt *Limit, Expr *Cond, Expr *Inc, DeclStmt *LoopIndexStmt);
 
   /// \brief Build an empty for range statement.
   explicit CilkForRangeStmt(EmptyShell Empty) : Stmt(CilkForRangeStmtClass, Empty) { }
@@ -111,11 +111,17 @@ public:
 
   Expr *getCond() { return reinterpret_cast<Expr*>(SubExprs[COND]); }
   Expr *getInc()  { return reinterpret_cast<Expr*>(SubExprs[INC]); }
+  DeclStmt *getLimitStmt() {
+    return cast_or_null<DeclStmt>(SubExprs[LIMIT]);
+  }
 
   const Expr *getCond() const { return reinterpret_cast<Expr*>(SubExprs[COND]);}
   const Expr *getInc()  const { return reinterpret_cast<Expr*>(SubExprs[INC]); }
   const DeclStmt *getLoopIndexStmt() const {
     return cast_or_null<DeclStmt>(SubExprs[LOOPINDEXSTMT]);
+  }
+  const DeclStmt *getLimitStmt() const {
+    return cast_or_null<DeclStmt>(SubExprs[LIMIT]);
   }
 
   SourceLocation getBeginLoc() const LLVM_READONLY;

--- a/clang/include/clang/Basic/DiagnosticParseKinds.td
+++ b/clang/include/clang/Basic/DiagnosticParseKinds.td
@@ -1221,8 +1221,6 @@ def err_cilk_for_missing_increment: Error<
   "missing loop increment expression in '_Cilk_for'">;
 def err_cilk_for_missing_semi: Error<
   "expected ';' in '_Cilk_for'">;
-def err_cilk_for_forrange_loop_not_supported: Error<
-  "'_Cilk_for' not supported on for-range loops">;
 def err_cilk_for_foreach_loop_not_supported: Error<
   "'_Cilk_for' not supported on for-each loops">;
 def err_pragma_cilk_invalid_option : Error<
@@ -1234,6 +1232,9 @@ def warn_cilk_for_following_grainsize: Warning<
   InGroup<SourceUsesCilkPlus>;
 def warn_pragma_cilk_grainsize_equals: Warning<
   "'#pragma cilk grainsize' no longer requires '='">,
+  InGroup<SourceUsesCilkPlus>;
+def warn_cilk_for_forrange_loop_experimental: Warning<
+  "'_Cilk_for' support for for-range loops is currently EXPERIMENTAL only!">,
   InGroup<SourceUsesCilkPlus>;
 
 // OpenMP support.

--- a/clang/include/clang/Basic/DiagnosticSemaKinds.td
+++ b/clang/include/clang/Basic/DiagnosticSemaKinds.td
@@ -9487,7 +9487,6 @@ def note_cilk_for_loop_control_var_declared_here: Note<
 def warn_empty_cilk_for_body : Warning<
   "Cilk for loop has empty body">, InGroup<EmptyBody>;
 
-
 def note_constant_stride: Note<
   "constant stride is %0">;
 def warn_cilk_for_cond_user_defined_conv: Warning<

--- a/clang/include/clang/Basic/DiagnosticSemaKinds.td
+++ b/clang/include/clang/Basic/DiagnosticSemaKinds.td
@@ -9523,8 +9523,8 @@ def err_jump_out_of_cilk_for : Error<
 
 // Cilk For Range errors
 
-def err_cilk_for_range_begin_minus_end : Error<
-  "Cannot determine length with '__begin - __end'. Please use a random access iterator.">;
+def err_cilk_for_range_end_minus_begin : Error<
+  "Cannot determine length with '__end - __begin'. Please use a random access iterator.">;
 } 
 // end of Cilk category
 

--- a/clang/include/clang/Basic/DiagnosticSemaKinds.td
+++ b/clang/include/clang/Basic/DiagnosticSemaKinds.td
@@ -10509,6 +10509,7 @@ def warn_sycl_kernel_num_of_template_params : Warning<
 def warn_sycl_kernel_invalid_template_param_type : Warning<
   "template parameter of a function template with the 'sycl_kernel' attribute"
   " cannot be a non-type template parameter">, InGroup<IgnoredAttributes>;
+  
 def warn_sycl_kernel_num_of_function_params : Warning<
   "function template with 'sycl_kernel' attribute must have a single parameter">,
   InGroup<IgnoredAttributes>;

--- a/clang/include/clang/Basic/DiagnosticSemaKinds.td
+++ b/clang/include/clang/Basic/DiagnosticSemaKinds.td
@@ -10515,5 +10515,5 @@ def warn_sycl_kernel_num_of_function_params : Warning<
 def warn_sycl_kernel_return_type : Warning<
   "function template with 'sycl_kernel' attribute must have a 'void' return type">,
   InGroup<IgnoredAttributes>;
-  
+
 } // end of sema component.

--- a/clang/include/clang/Basic/DiagnosticSemaKinds.td
+++ b/clang/include/clang/Basic/DiagnosticSemaKinds.td
@@ -10509,7 +10509,7 @@ def warn_sycl_kernel_num_of_template_params : Warning<
 def warn_sycl_kernel_invalid_template_param_type : Warning<
   "template parameter of a function template with the 'sycl_kernel' attribute"
   " cannot be a non-type template parameter">, InGroup<IgnoredAttributes>;
-  
+
 def warn_sycl_kernel_num_of_function_params : Warning<
   "function template with 'sycl_kernel' attribute must have a single parameter">,
   InGroup<IgnoredAttributes>;

--- a/clang/include/clang/Basic/DiagnosticSemaKinds.td
+++ b/clang/include/clang/Basic/DiagnosticSemaKinds.td
@@ -9487,6 +9487,7 @@ def note_cilk_for_loop_control_var_declared_here: Note<
 def warn_empty_cilk_for_body : Warning<
   "Cilk for loop has empty body">, InGroup<EmptyBody>;
 
+
 def note_constant_stride: Note<
   "constant stride is %0">;
 def warn_cilk_for_cond_user_defined_conv: Warning<
@@ -9519,7 +9520,13 @@ def note_exits_cilk_for : Note<
   "jump exits the scope of a '_Cilk_for'">;
 def err_jump_out_of_cilk_for : Error<
   "cannot jump out of '_Cilk_for' statement">;
-} // end of Cilk category
+
+// Cilk For Range errors
+
+def err_cilk_for_range_begin_minus_end : Error<
+  "Cannot determine length with '__begin - __end'. Please use a random access iterator.">;
+} 
+// end of Cilk category
 
 let CategoryName = "OpenMP Issue" in {
 // OpenMP support.
@@ -10509,5 +10516,4 @@ def warn_sycl_kernel_num_of_function_params : Warning<
 def warn_sycl_kernel_return_type : Warning<
   "function template with 'sycl_kernel' attribute must have a 'void' return type">,
   InGroup<IgnoredAttributes>;
-
 } // end of sema component.

--- a/clang/include/clang/Basic/DiagnosticSemaKinds.td
+++ b/clang/include/clang/Basic/DiagnosticSemaKinds.td
@@ -10509,11 +10509,11 @@ def warn_sycl_kernel_num_of_template_params : Warning<
 def warn_sycl_kernel_invalid_template_param_type : Warning<
   "template parameter of a function template with the 'sycl_kernel' attribute"
   " cannot be a non-type template parameter">, InGroup<IgnoredAttributes>;
-
 def warn_sycl_kernel_num_of_function_params : Warning<
   "function template with 'sycl_kernel' attribute must have a single parameter">,
   InGroup<IgnoredAttributes>;
 def warn_sycl_kernel_return_type : Warning<
   "function template with 'sycl_kernel' attribute must have a 'void' return type">,
   InGroup<IgnoredAttributes>;
+  
 } // end of sema component.

--- a/clang/include/clang/Basic/StmtNodes.td
+++ b/clang/include/clang/Basic/StmtNodes.td
@@ -215,6 +215,7 @@ def CilkSyncStmt : StmtNode<Stmt>;
 def CilkSpawnStmt : StmtNode<Stmt>;
 def CilkSpawnExpr : StmtNode<Expr>;
 def CilkForStmt : StmtNode<Stmt>;
+def CilkForRangeStmt: StmtNode<Stmt>;
 
 // OpenMP Directives.
 def OMPExecutableDirective : StmtNode<Stmt, 1>;

--- a/clang/include/clang/Sema/Sema.h
+++ b/clang/include/clang/Sema/Sema.h
@@ -12098,6 +12098,7 @@ public:
                                    SourceLocation ColonLoc, Expr *Range,
                                    SourceLocation RParenLoc,
                                    BuildForRangeKind Kind);
+  StmtResult BuildCilkForRangeStmt(CXXForRangeStmt *S);
   StmtResult FinishCilkForRangeStmt(Stmt *S, Stmt *B);
 };
 

--- a/clang/include/clang/Sema/Sema.h
+++ b/clang/include/clang/Sema/Sema.h
@@ -12093,6 +12093,12 @@ public:
     ConstructorDestructor,
     BuiltinFunction
   };
+  StmtResult ActOnCilkForRangeStmt(Scope *S, SourceLocation ForLoc,
+                                   Stmt *InitStmt, Stmt *First,
+                                   SourceLocation ColonLoc, Expr *Range,
+                                   SourceLocation RParenLoc,
+                                   BuildForRangeKind Kind);
+  StmtResult FinishCilkForRangeStmt(Stmt *S, Stmt *B);
 };
 
 /// RAII object that enters a new expression evaluation context.

--- a/clang/include/clang/Serialization/ASTBitCodes.h
+++ b/clang/include/clang/Serialization/ASTBitCodes.h
@@ -1877,6 +1877,7 @@ namespace serialization {
       EXPR_CILKSPAWN,
       STMT_CILKSYNC,
       STMT_CILKFOR,
+      STMT_CILKFORRANGE,
     };
 
     /// The kinds of designators that can occur in a

--- a/clang/lib/AST/Stmt.cpp
+++ b/clang/lib/AST/Stmt.cpp
@@ -1401,6 +1401,10 @@ void CilkForStmt::setLoopVariable(const ASTContext &C, VarDecl *V) {
   SubExprs[LOOPVAR] = new (C) DeclStmt(DeclGroupRef(V), VarRange.getBegin(),
                                        VarRange.getEnd());
 }
+
+CXXForRangeStmt* CilkForRangeStmt::getCXXForRangeStmt() const {
+  return cast_or_null<CXXForRangeStmt>(SubExprs[FORRANGE]);
+}
 SourceLocation CilkForRangeStmt::getBeginLoc() const LLVM_READONLY { return getCXXForRangeStmt()->getBeginLoc(); }
 SourceLocation CilkForRangeStmt::getEndLoc() const LLVM_READONLY {
   return getCXXForRangeStmt()->getEndLoc();

--- a/clang/lib/AST/Stmt.cpp
+++ b/clang/lib/AST/Stmt.cpp
@@ -1401,3 +1401,7 @@ void CilkForStmt::setLoopVariable(const ASTContext &C, VarDecl *V) {
   SubExprs[LOOPVAR] = new (C) DeclStmt(DeclGroupRef(V), VarRange.getBegin(),
                                        VarRange.getEnd());
 }
+SourceLocation CilkForRangeStmt::getBeginLoc() const LLVM_READONLY { return getCXXForRangeStmt()->getBeginLoc(); }
+SourceLocation CilkForRangeStmt::getEndLoc() const LLVM_READONLY {
+  return getCXXForRangeStmt()->getEndLoc();
+}

--- a/clang/lib/AST/Stmt.cpp
+++ b/clang/lib/AST/Stmt.cpp
@@ -1405,7 +1405,7 @@ void CilkForStmt::setLoopVariable(const ASTContext &C, VarDecl *V) {
 CXXForRangeStmt* CilkForRangeStmt::getCXXForRangeStmt() const {
   return cast_or_null<CXXForRangeStmt>(SubExprs[FORRANGE]);
 }
-SourceLocation CilkForRangeStmt::getBeginLoc() const LLVM_READONLY { return getCXXForRangeStmt()->getBeginLoc(); }
-SourceLocation CilkForRangeStmt::getEndLoc() const LLVM_READONLY {
+SourceLocation CilkForRangeStmt::getBeginLoc() const { return getCXXForRangeStmt()->getBeginLoc(); }
+SourceLocation CilkForRangeStmt::getEndLoc() const {
   return getCXXForRangeStmt()->getEndLoc();
 }

--- a/clang/lib/AST/Stmt.cpp
+++ b/clang/lib/AST/Stmt.cpp
@@ -1401,11 +1401,3 @@ void CilkForStmt::setLoopVariable(const ASTContext &C, VarDecl *V) {
   SubExprs[LOOPVAR] = new (C) DeclStmt(DeclGroupRef(V), VarRange.getBegin(),
                                        VarRange.getEnd());
 }
-
-CXXForRangeStmt* CilkForRangeStmt::getCXXForRangeStmt() const {
-  return cast_or_null<CXXForRangeStmt>(SubExprs[FORRANGE]);
-}
-SourceLocation CilkForRangeStmt::getBeginLoc() const { return getCXXForRangeStmt()->getBeginLoc(); }
-SourceLocation CilkForRangeStmt::getEndLoc() const {
-  return getCXXForRangeStmt()->getEndLoc();
-}

--- a/clang/lib/AST/StmtCXX.cpp
+++ b/clang/lib/AST/StmtCXX.cpp
@@ -128,12 +128,13 @@ CoroutineBodyStmt::CoroutineBodyStmt(CoroutineBodyStmt::CtorArgs const &Args)
 }
 
 CilkForRangeStmt::CilkForRangeStmt(const ASTContext &C, CXXForRangeStmt *ForRange,
-                                   VarDecl *LoopIndex, Expr *Cond)
+                                   VarDecl *LoopIndex, Expr *Cond, Expr *Inc)
   : Stmt(CilkForRangeStmtClass)
 {
   SubExprs[FORRANGE] = ForRange;
   setLoopIndex(C, LoopIndex);
   SubExprs[COND] = Cond;
+  SubExprs[INC] = Inc;
 }
 VarDecl *CilkForRangeStmt::getLoopIndex() const {
   if (!SubExprs[LOOPINDEX])

--- a/clang/lib/AST/StmtCXX.cpp
+++ b/clang/lib/AST/StmtCXX.cpp
@@ -128,7 +128,7 @@ CoroutineBodyStmt::CoroutineBodyStmt(CoroutineBodyStmt::CtorArgs const &Args)
 }
 
 CilkForRangeStmt::CilkForRangeStmt(const ASTContext &C, CXXForRangeStmt *ForRange,
-                                   VarDecl *LoopIndex, Expr *Cond, Expr *Inc, DeclStmt *LoopIndexStmt)
+                                   VarDecl *LoopIndex, DeclStmt *Limit, Expr *Cond, Expr *Inc, DeclStmt *LoopIndexStmt)
   : Stmt(CilkForRangeStmtClass)
 {
   SubExprs[FORRANGE] = ForRange;
@@ -136,6 +136,7 @@ CilkForRangeStmt::CilkForRangeStmt(const ASTContext &C, CXXForRangeStmt *ForRang
   SubExprs[COND] = Cond;
   SubExprs[INC] = Inc;
   SubExprs[LOOPINDEXSTMT] = LoopIndexStmt;
+  SubExprs[LIMIT] = Limit;
 }
 VarDecl *CilkForRangeStmt::getLoopIndex() const {
   if (!SubExprs[LOOPINDEX])

--- a/clang/lib/AST/StmtCXX.cpp
+++ b/clang/lib/AST/StmtCXX.cpp
@@ -127,10 +127,13 @@ CoroutineBodyStmt::CoroutineBodyStmt(CoroutineBodyStmt::CtorArgs const &Args)
             const_cast<Stmt **>(getParamMoves().data()));
 }
 
-CilkForRangeStmt::CilkForRangeStmt(const ASTContext &C, CXXForRangeStmt *ForRange,
-                                   VarDecl *LoopIndex, DeclStmt *Limit, Expr *Cond, Expr *Inc, DeclStmt *LoopIndexStmt)
-  : Stmt(CilkForRangeStmtClass)
-{
+/// Constructor for the CilkForRangeStmt
+CilkForRangeStmt::CilkForRangeStmt(const ASTContext &C,
+                                   CXXForRangeStmt *ForRange,
+                                   VarDecl *LoopIndex, DeclStmt *Limit,
+                                   Expr *Cond, Expr *Inc,
+                                   DeclStmt *LoopIndexStmt)
+    : Stmt(CilkForRangeStmtClass) {
   SubExprs[FORRANGE] = ForRange;
   setLoopIndex(C, LoopIndex);
   SubExprs[COND] = Cond;
@@ -138,6 +141,9 @@ CilkForRangeStmt::CilkForRangeStmt(const ASTContext &C, CXXForRangeStmt *ForRang
   SubExprs[LOOPINDEXSTMT] = LoopIndexStmt;
   SubExprs[LIMIT] = Limit;
 }
+
+/// Gets the LOOPINDEX as a VarDecl.
+/// LOOPINDEX is stored as a DeclStmt for the purpose of clean manipulation.
 VarDecl *CilkForRangeStmt::getLoopIndex() const {
   if (!SubExprs[LOOPINDEX])
     return nullptr;
@@ -153,14 +159,19 @@ void CilkForRangeStmt::setLoopIndex(const ASTContext &C, VarDecl *V) {
   }
 
   SourceRange VarRange = V->getSourceRange();
-  SubExprs[LOOPINDEX] = new (C) DeclStmt(DeclGroupRef(V), VarRange.getBegin(),
-                                       VarRange.getEnd());
+  SubExprs[LOOPINDEX] =
+      new (C) DeclStmt(DeclGroupRef(V), VarRange.getBegin(), VarRange.getEnd());
 }
 
-CXXForRangeStmt* CilkForRangeStmt::getCXXForRangeStmt() const {
+/// returns the FORRANGE stmt embedded in the CilkForRange. (May be null.)
+CXXForRangeStmt *CilkForRangeStmt::getCXXForRangeStmt() const {
   return cast_or_null<CXXForRangeStmt>(SubExprs[FORRANGE]);
 }
-SourceLocation CilkForRangeStmt::getBeginLoc() const { return getCXXForRangeStmt()->getBeginLoc(); }
+
+SourceLocation CilkForRangeStmt::getBeginLoc() const {
+  return getCXXForRangeStmt()->getBeginLoc();
+}
+
 SourceLocation CilkForRangeStmt::getEndLoc() const {
   return getCXXForRangeStmt()->getEndLoc();
 }

--- a/clang/lib/AST/StmtCXX.cpp
+++ b/clang/lib/AST/StmtCXX.cpp
@@ -130,8 +130,8 @@ CoroutineBodyStmt::CoroutineBodyStmt(CoroutineBodyStmt::CtorArgs const &Args)
 /// Constructor for the CilkForRangeStmt
 CilkForRangeStmt::CilkForRangeStmt(const ASTContext &C,
                                    CXXForRangeStmt *ForRange,
-                                   VarDecl *LoopIndex, DeclStmt *LocalLoopIndex, DeclStmt *Limit,
-                                   Expr *Cond, Expr *Inc,
+                                   VarDecl *LoopIndex, DeclStmt *LocalLoopIndex,
+                                   DeclStmt *Limit, Expr *Cond, Expr *Inc,
                                    DeclStmt *LoopIndexStmt)
     : Stmt(CilkForRangeStmtClass) {
   SubExprs[FORRANGE] = ForRange;

--- a/clang/lib/AST/StmtCXX.cpp
+++ b/clang/lib/AST/StmtCXX.cpp
@@ -163,6 +163,16 @@ void CilkForRangeStmt::setLoopIndex(const ASTContext &C, VarDecl *V) {
       new (C) DeclStmt(DeclGroupRef(V), VarRange.getBegin(), VarRange.getEnd());
 }
 
+VarDecl *CilkForRangeStmt::getLocalLoopIndex() {
+  Decl *LV = cast<DeclStmt>(getLocalLoopIndexStmt())->getSingleDecl();
+  assert(LV && "No local loop index in CilkForRangeStmt");
+  return cast<VarDecl>(LV);
+}
+
+const VarDecl *CilkForRangeStmt::getLocalLoopIndex() const {
+  return const_cast<CilkForRangeStmt *>(this)->getLocalLoopIndex();
+}
+
 /// returns the FORRANGE stmt embedded in the CilkForRange. (May be null.)
 CXXForRangeStmt *CilkForRangeStmt::getCXXForRangeStmt() const {
   return cast_or_null<CXXForRangeStmt>(SubExprs[FORRANGE]);

--- a/clang/lib/AST/StmtCXX.cpp
+++ b/clang/lib/AST/StmtCXX.cpp
@@ -128,13 +128,14 @@ CoroutineBodyStmt::CoroutineBodyStmt(CoroutineBodyStmt::CtorArgs const &Args)
 }
 
 CilkForRangeStmt::CilkForRangeStmt(const ASTContext &C, CXXForRangeStmt *ForRange,
-                                   VarDecl *LoopIndex, Expr *Cond, Expr *Inc)
+                                   VarDecl *LoopIndex, Expr *Cond, Expr *Inc, DeclStmt *LoopIndexStmt)
   : Stmt(CilkForRangeStmtClass)
 {
   SubExprs[FORRANGE] = ForRange;
   setLoopIndex(C, LoopIndex);
   SubExprs[COND] = Cond;
   SubExprs[INC] = Inc;
+  SubExprs[LOOPINDEXSTMT] = LoopIndexStmt;
 }
 VarDecl *CilkForRangeStmt::getLoopIndex() const {
   if (!SubExprs[LOOPINDEX])

--- a/clang/lib/AST/StmtCXX.cpp
+++ b/clang/lib/AST/StmtCXX.cpp
@@ -130,12 +130,13 @@ CoroutineBodyStmt::CoroutineBodyStmt(CoroutineBodyStmt::CtorArgs const &Args)
 /// Constructor for the CilkForRangeStmt
 CilkForRangeStmt::CilkForRangeStmt(const ASTContext &C,
                                    CXXForRangeStmt *ForRange,
-                                   VarDecl *LoopIndex, DeclStmt *Limit,
+                                   VarDecl *LoopIndex, DeclStmt *LocalLoopIndex, DeclStmt *Limit,
                                    Expr *Cond, Expr *Inc,
                                    DeclStmt *LoopIndexStmt)
     : Stmt(CilkForRangeStmtClass) {
   SubExprs[FORRANGE] = ForRange;
   setLoopIndex(C, LoopIndex);
+  SubExprs[LOCALLOOPINDEX] = LocalLoopIndex;
   SubExprs[COND] = Cond;
   SubExprs[INC] = Inc;
   SubExprs[LOOPINDEXSTMT] = LoopIndexStmt;

--- a/clang/lib/AST/StmtCXX.cpp
+++ b/clang/lib/AST/StmtCXX.cpp
@@ -135,7 +135,7 @@ CilkForRangeStmt::CilkForRangeStmt(const ASTContext &C, CXXForRangeStmt *ForRang
   setLoopVariable(C, LoopVar);
   SubExprs[COND] = Cond;
 }
-VarDecl *CilkForStmt::getLoopVariable() const {
+VarDecl *CilkForRangeStmt::getLoopVariable() const {
   if (!SubExprs[LOOPVAR])
     return nullptr;
 
@@ -143,7 +143,7 @@ VarDecl *CilkForStmt::getLoopVariable() const {
   return cast<VarDecl>(DS->getSingleDecl());
 }
 
-void CilkForStmt::setLoopVariable(const ASTContext &C, VarDecl *V) {
+void CilkForRangeStmt::setLoopVariable(const ASTContext &C, VarDecl *V) {
   if (!V) {
     SubExprs[LOOPVAR] = nullptr;
     return;

--- a/clang/lib/AST/StmtCXX.cpp
+++ b/clang/lib/AST/StmtCXX.cpp
@@ -11,7 +11,8 @@
 //===----------------------------------------------------------------------===//
 
 #include "clang/AST/StmtCXX.h"
-
+#include "clang/AST/Stmt.h"
+#include "clang/AST/StmtCilk.h"
 #include "clang/AST/ASTContext.h"
 
 using namespace clang;
@@ -124,4 +125,10 @@ CoroutineBodyStmt::CoroutineBodyStmt(CoroutineBodyStmt::CtorArgs const &Args)
       Args.ReturnStmtOnAllocFailure;
   std::copy(Args.ParamMoves.begin(), Args.ParamMoves.end(),
             const_cast<Stmt **>(getParamMoves().data()));
+}
+
+CilkForRangeStmt::CilkForRangeStmt(const ASTContext &C, CXXForRangeStmt *ForRange)
+  : Stmt(CilkForRangeStmtClass)
+{
+  SubExprs[FORRANGE] = ForRange;
 }

--- a/clang/lib/AST/StmtCXX.cpp
+++ b/clang/lib/AST/StmtCXX.cpp
@@ -128,29 +128,29 @@ CoroutineBodyStmt::CoroutineBodyStmt(CoroutineBodyStmt::CtorArgs const &Args)
 }
 
 CilkForRangeStmt::CilkForRangeStmt(const ASTContext &C, CXXForRangeStmt *ForRange,
-                                   VarDecl *LoopVar, Expr *Cond)
+                                   VarDecl *LoopIndex, Expr *Cond)
   : Stmt(CilkForRangeStmtClass)
 {
   SubExprs[FORRANGE] = ForRange;
-  setLoopVariable(C, LoopVar);
+  setLoopIndex(C, LoopIndex);
   SubExprs[COND] = Cond;
 }
-VarDecl *CilkForRangeStmt::getLoopVariable() const {
-  if (!SubExprs[LOOPVAR])
+VarDecl *CilkForRangeStmt::getLoopIndex() const {
+  if (!SubExprs[LOOPINDEX])
     return nullptr;
 
-  DeclStmt *DS = cast<DeclStmt>(SubExprs[LOOPVAR]);
+  DeclStmt *DS = cast<DeclStmt>(SubExprs[LOOPINDEX]);
   return cast<VarDecl>(DS->getSingleDecl());
 }
 
-void CilkForRangeStmt::setLoopVariable(const ASTContext &C, VarDecl *V) {
+void CilkForRangeStmt::setLoopIndex(const ASTContext &C, VarDecl *V) {
   if (!V) {
-    SubExprs[LOOPVAR] = nullptr;
+    SubExprs[LOOPINDEX] = nullptr;
     return;
   }
 
   SourceRange VarRange = V->getSourceRange();
-  SubExprs[LOOPVAR] = new (C) DeclStmt(DeclGroupRef(V), VarRange.getBegin(),
+  SubExprs[LOOPINDEX] = new (C) DeclStmt(DeclGroupRef(V), VarRange.getBegin(),
                                        VarRange.getEnd());
 }
 

--- a/clang/lib/AST/StmtPrinter.cpp
+++ b/clang/lib/AST/StmtPrinter.cpp
@@ -2564,16 +2564,20 @@ void StmtPrinter::VisitCilkForStmt(CilkForStmt *Node) {
 
 void StmtPrinter::VisitCilkForRangeStmt(CilkForRangeStmt *Node) {
   Indent() << "_Cilk_for (";
+
   if (Node->getCXXForRangeStmt()->getInit())
     PrintInitStmt(Node->getCXXForRangeStmt()->getInit(), 5);
+
   PrintingPolicy SubPolicy(Policy);
   SubPolicy.SuppressInitializers = true;
-  Node->getCXXForRangeStmt()->getLoopVariable()->print(OS, SubPolicy, IndentLevel);
+  Node->getCXXForRangeStmt()->getLoopVariable()->print(OS, SubPolicy,
+                                                       IndentLevel);
+
   OS << " : ";
   PrintExpr(Node->getCXXForRangeStmt()->getRangeInit());
   OS << ")";
-  PrintControlledStmt(Node->getCXXForRangeStmt()->getBody());
 
+  PrintControlledStmt(Node->getCXXForRangeStmt()->getBody());
 }
 
 //===----------------------------------------------------------------------===//

--- a/clang/lib/AST/StmtPrinter.cpp
+++ b/clang/lib/AST/StmtPrinter.cpp
@@ -2562,6 +2562,20 @@ void StmtPrinter::VisitCilkForStmt(CilkForStmt *Node) {
     Indent() << "}";
 }
 
+void StmtPrinter::VisitCilkForRangeStmt(CilkForRangeStmt *Node) {
+  Indent() << "_Cilk_for (";
+  if (Node->getCXXForRangeStmt()->getInit())
+    PrintInitStmt(Node->getCXXForRangeStmt()->getInit(), 5);
+  PrintingPolicy SubPolicy(Policy);
+  SubPolicy.SuppressInitializers = true;
+  Node->getCXXForRangeStmt()->getLoopVariable()->print(OS, SubPolicy, IndentLevel);
+  OS << " : ";
+  PrintExpr(Node->getCXXForRangeStmt()->getRangeInit());
+  OS << ")";
+  PrintControlledStmt(Node->getCXXForRangeStmt()->getBody());
+
+}
+
 //===----------------------------------------------------------------------===//
 // Stmt method implementations
 //===----------------------------------------------------------------------===//

--- a/clang/lib/AST/StmtProfile.cpp
+++ b/clang/lib/AST/StmtProfile.cpp
@@ -1982,6 +1982,10 @@ void StmtProfiler::VisitCilkForStmt(const CilkForStmt *S) {
   VisitStmt(S);
 }
 
+void StmtProfiler::VisitCilkForRangeStmt(const CilkForRangeStmt *S) {
+  VisitStmt(S);
+}
+
 void StmtProfiler::VisitCilkSpawnStmt(const CilkSpawnStmt *S) {
   VisitStmt(S);
 }

--- a/clang/lib/CodeGen/CGCilk.cpp
+++ b/clang/lib/CodeGen/CGCilk.cpp
@@ -970,7 +970,7 @@ CodeGenFunction::EmitCilkForRangeStmt(const CilkForRangeStmt &S,
 //    EmitStoreThroughLValue(LoopVarInitRV, LV, true);
 //    EmitAutoVarCleanups(LVEmission);
 //  }
-//  EmitStmt(S.getLoopVarStmt());
+  EmitStmt(ForRange.getLoopVarStmt());
 
   Builder.CreateBr(ForBody);
 
@@ -984,12 +984,12 @@ CodeGenFunction::EmitCilkForRangeStmt(const CilkForRangeStmt &S,
     // NO! Instead, always create a new lexical scope because we want to emit
     // the loop var stmt and then the body, so it doesn't matter if the
     // body is a compound statement or not.
-    LexicalScope BodyScope(*this, ForRange.getSourceRange());
+    RunCleanupsScope BodyScope(*this);
 
     SyncedScopeRAII SyncedScp(*this);
-//    if (isa<CompoundStmt>(ForRange.getBody()))
+    if (isa<CompoundStmt>(ForRange.getBody()))
       ScopeIsSynced = true;
-    EmitStmt(ForRange.getLoopVarStmt());
+//    EmitStmt(ForRange.getLoopVarStmt());
     EmitStmt(ForRange.getBody());
 
     if (HaveInsertPoint())

--- a/clang/lib/CodeGen/CGCilk.cpp
+++ b/clang/lib/CodeGen/CGCilk.cpp
@@ -986,9 +986,9 @@ CodeGenFunction::EmitCilkForRangeStmt(const CilkForRangeStmt &S,
     // body is a compound statement or not.
     LexicalScope BodyScope(*this, ForRange.getSourceRange());
 
-//    SyncedScopeRAII SyncedScp(*this);
+    SyncedScopeRAII SyncedScp(*this);
 //    if (isa<CompoundStmt>(ForRange.getBody()))
-//      ScopeIsSynced = true;
+      ScopeIsSynced = true;
     EmitStmt(ForRange.getLoopVarStmt());
     EmitStmt(ForRange.getBody());
 

--- a/clang/lib/CodeGen/CGCilk.cpp
+++ b/clang/lib/CodeGen/CGCilk.cpp
@@ -914,8 +914,6 @@ void CodeGenFunction::EmitCilkForRangeStmt(const CilkForRangeStmt &S,
     // Get the value of the loop variable initialization before we emit the
     // detach.
     if (LoopVar) {
-      LoopVar->dump();
-      LoopVar->dumpColor();
       LoopVarInitRV = EmitAnyExprToTemp(LoopVar->getInit());
     }
 

--- a/clang/lib/CodeGen/CGCilk.cpp
+++ b/clang/lib/CodeGen/CGCilk.cpp
@@ -861,7 +861,7 @@ void CodeGenFunction::EmitCilkForRangeStmt(const CilkForRangeStmt &S,
                  SourceLocToDebugLoc(R.getBegin()),
                  SourceLocToDebugLoc(R.getEnd()));
 
-  const Expr *Inc = ForRange.getInc();
+  const Expr *Inc = S.getInc();
   assert(Inc && "_Cilk_for range loop has no increment");
   Continue = getJumpDestInCurrentScope("pfor.inc");
 
@@ -1077,10 +1077,10 @@ void CodeGenFunction::EmitCilkForRangeStmt(const CilkForRangeStmt &S,
 
   // C99 6.8.5p2/p4: The first substatement is executed if the expression
   // compares unequal to 0.  The condition must be a scalar type.
-  llvm::Value *BoolCondVal = EvaluateExprAsBool(ForRange.getCond());
+  llvm::Value *BoolCondVal = EvaluateExprAsBool(S.getCond());
   Builder.CreateCondBr(
       BoolCondVal, CondBlock, ExitBlock,
-      createProfileWeightsForLoop(ForRange.getCond(), getProfileCount(ForRange.getBody())));
+      createProfileWeightsForLoop(S.getCond(), getProfileCount(ForRange.getBody())));
 
   if (ExitBlock != LoopExit.getBlock()) {
     EmitBlock(ExitBlock);

--- a/clang/lib/CodeGen/CGCilk.cpp
+++ b/clang/lib/CodeGen/CGCilk.cpp
@@ -970,6 +970,8 @@ CodeGenFunction::EmitCilkForRangeStmt(const CilkForRangeStmt &S,
 //    EmitStoreThroughLValue(LoopVarInitRV, LV, true);
 //    EmitAutoVarCleanups(LVEmission);
 //  }
+  // TODO: create a cleanup scope here?
+  // TODO: performance problems when emitting everything here?
   EmitStmt(ForRange.getLoopVarStmt());
 
   Builder.CreateBr(ForBody);
@@ -981,14 +983,12 @@ CodeGenFunction::EmitCilkForRangeStmt(const CilkForRangeStmt &S,
   {
     // Create a separate cleanup scope for the body, in case it is not
     // a compound statement.
-    // NO! Instead, always create a new lexical scope because we want to emit
-    // the loop var stmt and then the body, so it doesn't matter if the
-    // body is a compound statement or not.
     RunCleanupsScope BodyScope(*this);
 
     SyncedScopeRAII SyncedScp(*this);
     if (isa<CompoundStmt>(ForRange.getBody()))
       ScopeIsSynced = true;
+    // TODO: why does the cleanup crash if we emit the loop var stmt here?
 //    EmitStmt(ForRange.getLoopVarStmt());
     EmitStmt(ForRange.getBody());
 

--- a/clang/lib/CodeGen/CGCilk.cpp
+++ b/clang/lib/CodeGen/CGCilk.cpp
@@ -912,8 +912,11 @@ void CodeGenFunction::EmitCilkForRangeStmt(const CilkForRangeStmt &S,
 
     // Get the value of the loop variable initialization before we emit the
     // detach.
-    if (LoopVar)
+    if (LoopVar) {
+      LoopVar->dump();
+      LoopVar->dumpColor();
       LoopVarInitRV = EmitAnyExprToTemp(LoopVar->getInit());
+    }
 
     Detach = Builder.CreateDetach(ForBodyEntry, Continue.getBlock(),
                                   SyncRegion);

--- a/clang/lib/CodeGen/CGCilk.cpp
+++ b/clang/lib/CodeGen/CGCilk.cpp
@@ -986,8 +986,6 @@ CodeGenFunction::EmitCilkForRangeStmt(const CilkForRangeStmt &S,
     SyncedScopeRAII SyncedScp(*this);
     if (isa<CompoundStmt>(ForRange.getBody()))
       ScopeIsSynced = true;
-    // TODO: why does the cleanup crash if we emit the loop var stmt here?
-//    EmitStmt(ForRange.getLoopVarStmt());
     EmitStmt(ForRange.getBody());
 
     if (HaveInsertPoint())

--- a/clang/lib/CodeGen/CGCilk.cpp
+++ b/clang/lib/CodeGen/CGCilk.cpp
@@ -882,8 +882,8 @@ CodeGenFunction::EmitCilkForRangeStmt(const CilkForRangeStmt &S,
   llvm::AllocaInst *OldEHSelectorSlot;
   Address OldNormalCleanupDest = Address::invalid();
 
-  const VarDecl *LoopVar = ForRange.getLoopVariable();
-  RValue LoopVarInitRV;
+//  const VarDecl *LoopVar = ForRange.getLoopVariable();
+//  RValue LoopVarInitRV;
   llvm::BasicBlock *DetachBlock;
   llvm::BasicBlock *ForBodyEntry;
   llvm::BasicBlock *ForBody;
@@ -916,9 +916,9 @@ CodeGenFunction::EmitCilkForRangeStmt(const CilkForRangeStmt &S,
 
     // Get the value of the loop variable initialization before we emit the
     // detach.
-    if (LoopVar) {
-      LoopVarInitRV = EmitAnyExprToTemp(LoopVar->getInit());
-    }
+//    if (LoopVar) {
+//      LoopVarInitRV = EmitAnyExprToTemp(LoopVar->getInit());
+//    }
 
     Detach =
         Builder.CreateDetach(ForBodyEntry, Continue.getBlock(), SyncRegion);
@@ -961,15 +961,16 @@ CodeGenFunction::EmitCilkForRangeStmt(const CilkForRangeStmt &S,
 
   // Inside the detached block, create the loop variable, setting its value to
   // the saved initialization value.
-  if (LoopVar) {
-    AutoVarEmission LVEmission = EmitAutoVarAlloca(*LoopVar);
-    QualType type = LoopVar->getType();
-    Address Loc = LVEmission.getObjectAddress(*this);
-    LValue LV = MakeAddrLValue(Loc, type);
-    LV.setNonGC(true);
-    EmitStoreThroughLValue(LoopVarInitRV, LV, true);
-    EmitAutoVarCleanups(LVEmission);
-  }
+//  if (LoopVar) {
+//    AutoVarEmission LVEmission = EmitAutoVarAlloca(*LoopVar);
+//    QualType type = LoopVar->getType();
+//    Address Loc = LVEmission.getObjectAddress(*this);
+//    LValue LV = MakeAddrLValue(Loc, type);
+//    LV.setNonGC(true);
+//    EmitStoreThroughLValue(LoopVarInitRV, LV, true);
+//    EmitAutoVarCleanups(LVEmission);
+//  }
+//  EmitStmt(S.getLoopVarStmt());
 
   Builder.CreateBr(ForBody);
 
@@ -985,6 +986,7 @@ CodeGenFunction::EmitCilkForRangeStmt(const CilkForRangeStmt &S,
     SyncedScopeRAII SyncedScp(*this);
     if (isa<CompoundStmt>(ForRange.getBody()))
       ScopeIsSynced = true;
+    EmitStmt(ForRange.getLoopVarStmt());
     EmitStmt(ForRange.getBody());
 
     if (HaveInsertPoint())

--- a/clang/lib/CodeGen/CGCilk.cpp
+++ b/clang/lib/CodeGen/CGCilk.cpp
@@ -981,11 +981,14 @@ CodeGenFunction::EmitCilkForRangeStmt(const CilkForRangeStmt &S,
   {
     // Create a separate cleanup scope for the body, in case it is not
     // a compound statement.
-    RunCleanupsScope BodyScope(*this);
+    // NO! Instead, always create a new lexical scope because we want to emit
+    // the loop var stmt and then the body, so it doesn't matter if the
+    // body is a compound statement or not.
+    LexicalScope BodyScope(*this, ForRange.getSourceRange());
 
-    SyncedScopeRAII SyncedScp(*this);
-    if (isa<CompoundStmt>(ForRange.getBody()))
-      ScopeIsSynced = true;
+//    SyncedScopeRAII SyncedScp(*this);
+//    if (isa<CompoundStmt>(ForRange.getBody()))
+//      ScopeIsSynced = true;
     EmitStmt(ForRange.getLoopVarStmt());
     EmitStmt(ForRange.getBody());
 

--- a/clang/lib/CodeGen/CGCilk.cpp
+++ b/clang/lib/CodeGen/CGCilk.cpp
@@ -847,6 +847,7 @@ void CodeGenFunction::EmitCilkForRangeStmt(const CilkForRangeStmt &S,
   EmitStmt(ForRange.getRangeStmt());
   EmitStmt(ForRange.getBeginStmt());
   EmitStmt(ForRange.getEndStmt());
+  EmitStmt(S.getLoopIndexStmt());
 
   // Start the loop with a block that tests the condition.  If there's an
   // increment, the continue scope will be overwritten later.

--- a/clang/lib/CodeGen/CGCilk.cpp
+++ b/clang/lib/CodeGen/CGCilk.cpp
@@ -838,6 +838,12 @@ void CodeGenFunction::EmitCilkForRangeStmt(const CilkForRangeStmt &S,
 
   llvm::BasicBlock *ExitBlock = LoopExit.getBlock();
 
+  // TODO: emit difference variable instead of beginstmt and endstmt
+  // plan: 
+  // 1. add difference variable and emit it, check
+  // 2. make loop condition depend on the difference variable instead, check
+  // 3. finally, don't mutate beginstmt and instead do begin=begin+inductionvar
+
   EmitStmt(ForRange.getRangeStmt());
   EmitStmt(ForRange.getBeginStmt());
   EmitStmt(ForRange.getEndStmt());

--- a/clang/lib/CodeGen/CGCilk.cpp
+++ b/clang/lib/CodeGen/CGCilk.cpp
@@ -848,6 +848,7 @@ void CodeGenFunction::EmitCilkForRangeStmt(const CilkForRangeStmt &S,
   EmitStmt(ForRange.getBeginStmt());
   EmitStmt(ForRange.getEndStmt());
   EmitStmt(S.getLoopIndexStmt());
+  EmitStmt(S.getLimitStmt());
 
   // Start the loop with a block that tests the condition.  If there's an
   // increment, the continue scope will be overwritten later.

--- a/clang/lib/CodeGen/CGStmt.cpp
+++ b/clang/lib/CodeGen/CGStmt.cpp
@@ -167,7 +167,7 @@ void CodeGenFunction::EmitStmt(const Stmt *S, ArrayRef<const Attr *> Attrs) {
     break;
   case Stmt::CilkForRangeStmtClass:
     // TODO(cilkforrange): emit the right thing here!
-    EmitCXXForRangeStmt(cast<CilkForRangeStmt>(*S)->getCXXForRangeStmt(), Attrs);
+    EmitCXXForRangeStmt(*cast<CilkForRangeStmt>(*S).getCXXForRangeStmt(), Attrs);
     break;
   case Stmt::ObjCAtTryStmtClass:
     EmitObjCAtTryStmt(cast<ObjCAtTryStmt>(*S));

--- a/clang/lib/CodeGen/CGStmt.cpp
+++ b/clang/lib/CodeGen/CGStmt.cpp
@@ -166,8 +166,7 @@ void CodeGenFunction::EmitStmt(const Stmt *S, ArrayRef<const Attr *> Attrs) {
     EmitCilkForStmt(cast<CilkForStmt>(*S), Attrs);
     break;
   case Stmt::CilkForRangeStmtClass:
-    // TODO(cilkforrange): emit the right thing here!
-    EmitCXXForRangeStmt(*cast<CilkForRangeStmt>(*S).getCXXForRangeStmt(), Attrs);
+    EmitCilkForRangeStmt(cast<CilkForRangeStmt>(*S), Attrs);
     break;
   case Stmt::ObjCAtTryStmtClass:
     EmitObjCAtTryStmt(cast<ObjCAtTryStmt>(*S));

--- a/clang/lib/CodeGen/CGStmt.cpp
+++ b/clang/lib/CodeGen/CGStmt.cpp
@@ -165,6 +165,10 @@ void CodeGenFunction::EmitStmt(const Stmt *S, ArrayRef<const Attr *> Attrs) {
   case Stmt::CilkForStmtClass:
     EmitCilkForStmt(cast<CilkForStmt>(*S), Attrs);
     break;
+  case Stmt::CilkForRangeStmtClass:
+    // TODO(cilkforrange): emit the right thing here!
+    EmitCXXForRangeStmt(cast<CilkForRangeStmt>(*S)->getCXXForRangeStmt(), Attrs);
+    break;
   case Stmt::ObjCAtTryStmtClass:
     EmitObjCAtTryStmt(cast<ObjCAtTryStmt>(*S));
     break;

--- a/clang/lib/CodeGen/CodeGenFunction.h
+++ b/clang/lib/CodeGen/CodeGenFunction.h
@@ -3441,6 +3441,8 @@ public:
   void EmitCilkSyncStmt(const CilkSyncStmt &S);
   void EmitCilkForStmt(const CilkForStmt &S,
                        ArrayRef<const Attr *> Attrs = None);
+  void EmitCilkForRangeStmt(const CilkForRangeStmt &S,
+                       ArrayRef<const Attr *> Attrs = None);
   LValue EmitCilkSpawnExprLValue(const CilkSpawnExpr *E);
 
   void EmitObjCForCollectionStmt(const ObjCForCollectionStmt &S);
@@ -4934,8 +4936,6 @@ private:
   llvm::Value *EmitX86CpuSupports(uint64_t Mask);
   llvm::Value *EmitX86CpuInit();
   llvm::Value *FormResolverCondition(const MultiVersionResolverOption &RO);
-  void EmitCilkForRangeStmt(const CilkForRangeStmt &S,
-                            ArrayRef<const Attr *> ForAttrs);
 };
 
 inline DominatingLLVMValue::saved_type

--- a/clang/lib/CodeGen/CodeGenFunction.h
+++ b/clang/lib/CodeGen/CodeGenFunction.h
@@ -4934,6 +4934,8 @@ private:
   llvm::Value *EmitX86CpuSupports(uint64_t Mask);
   llvm::Value *EmitX86CpuInit();
   llvm::Value *FormResolverCondition(const MultiVersionResolverOption &RO);
+  void EmitCilkForRangeStmt(const CilkForRangeStmt &S,
+                            ArrayRef<const Attr *> ForAttrs);
 };
 
 inline DominatingLLVMValue::saved_type

--- a/clang/lib/Parse/ParseCilk.cpp
+++ b/clang/lib/Parse/ParseCilk.cpp
@@ -316,7 +316,7 @@ StmtResult Parser::ParseCilkForStatement(SourceLocation *TrailingElseLoc) {
 
   // TODO: Extend _Cilk_for to support these.
   if (ForRangeInfo.ParsedForRangeDecl()) {
-    Diag(ForLoc, diag::err_cilk_for_forrange_loop_not_supported);
+    Diag(ForLoc, diag::warn_cilk_for_forrange_loop_experimental);
      ExprResult CorrectedRange =
          Actions.CorrectDelayedTyposInExpr(ForRangeInfo.RangeExpr.get());
     // TODO(arvid): uncomment this

--- a/clang/lib/Parse/ParseCilk.cpp
+++ b/clang/lib/Parse/ParseCilk.cpp
@@ -318,19 +318,16 @@ StmtResult Parser::ParseCilkForStatement(SourceLocation *TrailingElseLoc) {
   //   CoawaitLoc = SourceLocation();
   // }
 
-  // // We need to perform most of the semantic analysis for a C++0x for-range
-  // // statememt before parsing the body, in order to be able to deduce the
-  // type
-  // // of an auto-typed loop variable.
+  // We need to perform most of the semantic analysis for a C++0x for-range
+  // statement before parsing the body, in order to be able to deduce the type
+  // of an auto-typed loop variable.
   StmtResult ForRangeStmt;
   // StmtResult ForEachStmt;
 
-  // TODO: Extend _Cilk_for to support these.
   if (ForRangeInfo.ParsedForRangeDecl()) {
     Diag(ForLoc, diag::warn_cilk_for_forrange_loop_experimental);
     ExprResult CorrectedRange =
         Actions.CorrectDelayedTyposInExpr(ForRangeInfo.RangeExpr.get());
-    // TODO(arvid): uncomment this
     ForRangeStmt = Actions.ActOnCilkForRangeStmt(
         getCurScope(), ForLoc, FirstPart.get(), ForRangeInfo.LoopVar.get(),
         ForRangeInfo.ColonLoc, CorrectedRange.get(), T.getCloseLocation(),

--- a/clang/lib/Parse/ParseCilk.cpp
+++ b/clang/lib/Parse/ParseCilk.cpp
@@ -69,7 +69,7 @@ StmtResult Parser::ParseCilkSpawnStatement() {
 
 StmtResult Parser::ParseCilkForStatement(SourceLocation *TrailingElseLoc) {
   assert(Tok.is(tok::kw__Cilk_for) && "Not a _Cilk_for stmt!");
-  SourceLocation ForLoc = ConsumeToken();  // eat the '_Cilk_for'.
+  SourceLocation ForLoc = ConsumeToken(); // eat the '_Cilk_for'.
 
   // SourceLocation CoawaitLoc;
   // if (Tok.is(tok::kw_co_await))
@@ -81,8 +81,8 @@ StmtResult Parser::ParseCilkForStatement(SourceLocation *TrailingElseLoc) {
     return StmtError();
   }
 
-  bool C99orCXXorObjC = getLangOpts().C99 || getLangOpts().CPlusPlus ||
-    getLangOpts().ObjC;
+  bool C99orCXXorObjC =
+      getLangOpts().C99 || getLangOpts().CPlusPlus || getLangOpts().ObjC;
 
   // A _Cilk_for statement is a block.  Start the loop scope.
   //
@@ -126,7 +126,7 @@ StmtResult Parser::ParseCilkForStatement(SourceLocation *TrailingElseLoc) {
   SourceLocation EmptyInitStmtSemiLoc;
 
   // Parse the first part of the for specifier.
-  if (Tok.is(tok::semi)) {  // _Cilk_for (;
+  if (Tok.is(tok::semi)) { // _Cilk_for (;
     ProhibitAttributes(attrs);
     // We disallow this syntax for now.
     Diag(Tok, diag::err_cilk_for_missing_control_variable) << ";";
@@ -145,15 +145,15 @@ StmtResult Parser::ParseCilkForStatement(SourceLocation *TrailingElseLoc) {
       ForRangeInfo.RangeExpr = ParseExpression();
 
     Diag(Loc, diag::err_for_range_identifier)
-      << ((getLangOpts().CPlusPlus11 && !getLangOpts().CPlusPlus17)
-              ? FixItHint::CreateInsertion(Loc, "auto &&")
-              : FixItHint());
+        << ((getLangOpts().CPlusPlus11 && !getLangOpts().CPlusPlus17)
+                ? FixItHint::CreateInsertion(Loc, "auto &&")
+                : FixItHint());
 
-    ForRangeInfo.LoopVar = Actions.ActOnCXXForRangeIdentifier(getCurScope(), Loc, Name,
-                                                   attrs, attrs.Range.getEnd());
-  } else if (isForInitDeclaration()) {  // _Cilk_for (int X = 4;
+    ForRangeInfo.LoopVar = Actions.ActOnCXXForRangeIdentifier(
+        getCurScope(), Loc, Name, attrs, attrs.Range.getEnd());
+  } else if (isForInitDeclaration()) { // _Cilk_for (int X = 4;
     // Parse declaration, which eats the ';'.
-    if (!C99orCXXorObjC)   // Use of C99-style for loops in C90 mode?
+    if (!C99orCXXorObjC) // Use of C99-style for loops in C90 mode?
       Diag(Tok, diag::ext_c99_variable_decl_in_for_loop);
 
     // In C++0x, "for (T NS:a" might not be a typo for ::
@@ -166,11 +166,12 @@ StmtResult Parser::ParseCilkForStatement(SourceLocation *TrailingElseLoc) {
         MightBeForRangeStmt ? &ForRangeInfo : nullptr);
     FirstPart = Actions.ActOnDeclStmt(DG, DeclStart, Tok.getLocation());
     if (ForRangeInfo.ParsedForRangeDecl()) {
-      Diag(ForRangeInfo.ColonLoc, getLangOpts().CPlusPlus11 ?
-           diag::warn_cxx98_compat_for_range : diag::ext_for_range);
+      Diag(ForRangeInfo.ColonLoc, getLangOpts().CPlusPlus11
+                                      ? diag::warn_cxx98_compat_for_range
+                                      : diag::ext_for_range);
       ForRangeInfo.LoopVar = FirstPart;
       FirstPart = StmtResult();
-    } else if (Tok.is(tok::semi)) {  // for (int x = 4;
+    } else if (Tok.is(tok::semi)) { // for (int x = 4;
       ConsumeToken();
     } else if ((ForEach = isTokIdentifier_in())) {
       Actions.ActOnForEachDeclStmt(DG);
@@ -219,11 +220,12 @@ StmtResult Parser::ParseCilkForStatement(SourceLocation *TrailingElseLoc) {
         return StmtError();
       }
       Collection = ParseExpression();
-    } else if (getLangOpts().CPlusPlus11 && Tok.is(tok::colon) && FirstPart.get()) {
+    } else if (getLangOpts().CPlusPlus11 && Tok.is(tok::colon) &&
+               FirstPart.get()) {
       // User tried to write the reasonable, but ill-formed, for-range-statement
       //   for (expr : expr) { ... }
       Diag(Tok, diag::err_for_range_expected_decl)
-        << FirstPart.get()->getSourceRange();
+          << FirstPart.get()->getSourceRange();
       SkipUntil(tok::r_paren, StopBeforeMatch);
       SecondPart = Sema::ConditionError();
     } else {
@@ -240,16 +242,17 @@ StmtResult Parser::ParseCilkForStatement(SourceLocation *TrailingElseLoc) {
 
   // Parse the second part of the for specifier.
   getCurScope()->AddFlags(Scope::BreakScope | Scope::ContinueScope);
-  if (!ForEach && !ForRangeInfo.ParsedForRangeDecl() && !SecondPart.isInvalid()) {
+  if (!ForEach && !ForRangeInfo.ParsedForRangeDecl() &&
+      !SecondPart.isInvalid()) {
     // Parse the second part of the for specifier.
-    if (Tok.is(tok::semi)) {  // for (...;;
+    if (Tok.is(tok::semi)) { // for (...;;
       // no second part.
       Diag(Tok, diag::err_cilk_for_missing_condition)
-        << FirstPart.get()->getSourceRange();
+          << FirstPart.get()->getSourceRange();
     } else if (Tok.is(tok::r_paren)) {
       // missing both semicolons.
       Diag(Tok, diag::err_cilk_for_missing_condition)
-        << FirstPart.get()->getSourceRange();
+          << FirstPart.get()->getSourceRange();
     } else {
       if (getLangOpts().CPlusPlus) {
         // C++2a: We've parsed an init-statement; we might have a
@@ -387,9 +390,8 @@ StmtResult Parser::ParseCilkForStatement(SourceLocation *TrailingElseLoc) {
   //  return Actions.FinishObjCForCollectionStmt(ForEachStmt.get(),
   //                                             Body.get());
 
-  // TODO(arvid): uncomment this
-   if (ForRangeInfo.ParsedForRangeDecl())
-     return Actions.FinishCilkForRangeStmt(ForRangeStmt.get(), Body.get());
+  if (ForRangeInfo.ParsedForRangeDecl())
+    return Actions.FinishCilkForRangeStmt(ForRangeStmt.get(), Body.get());
 
   return Actions.ActOnCilkForStmt(ForLoc, T.getOpenLocation(), FirstPart.get(),
                                   nullptr, Sema::ConditionResult(), nullptr,

--- a/clang/lib/Parse/ParseCilk.cpp
+++ b/clang/lib/Parse/ParseCilk.cpp
@@ -60,6 +60,12 @@ StmtResult Parser::ParseCilkSpawnStatement() {
 /// [C++0x] '_Cilk_for'
 ///             '(' for-range-declaration ':' for-range-initializer ')'
 ///             statement
+///
+/// [C++0x] for-range-declaration:
+/// [C++0x]   attribute-specifier-seq[opt] type-specifier-seq declarator
+/// [C++0x] for-range-initializer:
+/// [C++0x]   expression
+/// [C++0x]   braced-init-list
 
 StmtResult Parser::ParseCilkForStatement(SourceLocation *TrailingElseLoc) {
   assert(Tok.is(tok::kw__Cilk_for) && "Not a _Cilk_for stmt!");

--- a/clang/lib/Parse/ParseCilk.cpp
+++ b/clang/lib/Parse/ParseCilk.cpp
@@ -320,10 +320,10 @@ StmtResult Parser::ParseCilkForStatement(SourceLocation *TrailingElseLoc) {
      ExprResult CorrectedRange =
          Actions.CorrectDelayedTyposInExpr(ForRangeInfo.RangeExpr.get());
     // TODO(arvid): uncomment this
-//     ForRangeStmt = Actions.ActIsRangeBasedForOnCXXForRangeStmt(
-//         getCurScope(), ForLoc, CoawaitLoc, FirstPart.get(),
-//         ForRangeInit.ColonLoc, CorrectedRange.get(),
-//         T.getCloseLocation(), Sema::BFRK_Build);
+     ForRangeStmt = Actions.ActOnCilkForRangeStmt(
+         getCurScope(), ForLoc, FirstPart.get(),
+         ForRangeInfo.LoopVar.get(), ForRangeInfo.ColonLoc, CorrectedRange.get(),
+         T.getCloseLocation(), Sema::BFRK_Build);
 
 
   // Similarly, we need to do the semantic analysis for a for-range
@@ -381,8 +381,8 @@ StmtResult Parser::ParseCilkForStatement(SourceLocation *TrailingElseLoc) {
   //                                             Body.get());
 
   // TODO(arvid): uncomment this
-//   if (ForRangeInfo.ParsedForRangeDecl())
-//     return Actions.FinishCXXForRangeStmt(ForRangeStmt.get(), Body.get());
+   if (ForRangeInfo.ParsedForRangeDecl())
+     return Actions.FinishCilkForRangeStmt(ForRangeStmt.get(), Body.get());
 
   return Actions.ActOnCilkForStmt(ForLoc, T.getOpenLocation(), FirstPart.get(),
                                   nullptr, Sema::ConditionResult(), nullptr,

--- a/clang/lib/Sema/SemaExceptionSpec.cpp
+++ b/clang/lib/Sema/SemaExceptionSpec.cpp
@@ -1483,6 +1483,7 @@ CanThrowResult Sema::canThrow(const Stmt *S) {
   case Stmt::CilkSpawnStmtClass:
   case Stmt::CilkSyncStmtClass:
   case Stmt::CilkForStmtClass:
+  case Stmt::CilkForRangeStmtClass:
     return canSubStmtsThrow(*this, S);
 
   case Stmt::DeclStmtClass: {

--- a/clang/lib/Sema/SemaStmt.cpp
+++ b/clang/lib/Sema/SemaStmt.cpp
@@ -3607,7 +3607,7 @@ StmtResult Sema::BuildCilkForRangeStmt(CXXForRangeStmt *ForRange) {
   if (NewInc.isInvalid())
     return StmtError();
 
-  return new (Context) CilkForRangeStmt(Context, ForRange, LoopIndexStmt.get(), Cond.get(), NewInc.get(), cast<DeclStmt>(LoopIndexStmt.get()));
+  return new (Context) CilkForRangeStmt(Context, ForRange, LoopIndex, Cond.get(), NewInc.get(), cast<DeclStmt>(LoopIndexStmt.get()));
 }
 
 

--- a/clang/lib/Sema/SemaStmt.cpp
+++ b/clang/lib/Sema/SemaStmt.cpp
@@ -3586,8 +3586,14 @@ StmtResult Sema::BuildCilkForRangeStmt(CXXForRangeStmt *ForRange) {
   if (Cond.isInvalid())
     return StmtError();
 
+  // Create a new increment operation on the new beginning variable, and add it
+  // to the existing increment operation.
+  SourceLocation IncLoc = RangeLoc;
+  ExprResult NewInc = ActOnUnaryOp(S, IncLoc, tok::plusplus, LoopIndexRef.get());
+  if (NewInc.isInvalid())
+    return StmtError();
 
-  return new (Context) CilkForRangeStmt(Context, ForRange, LoopIndexRef, Cond.get());
+  return new (Context) CilkForRangeStmt(Context, ForRange, LoopIndex, Cond.get(), NewInc.get());
 }
 
 

--- a/clang/lib/Sema/SemaStmt.cpp
+++ b/clang/lib/Sema/SemaStmt.cpp
@@ -3525,7 +3525,7 @@ StmtResult Sema::FinishCilkForRangeStmt(Stmt *S, Stmt *B) {
   ExprResult NewLoopVarInit =
       ActOnBinOp(getCurScope(), LoopVarLoc, tok::plus, BeginRef.get(), LoopIndexRef.get());
 
-  ExprResult DerefExpr = ActOnUnaryOp(S, LoopVarLoc, tok::star, NewLoopVarInit.get());
+  ExprResult DerefExpr = ActOnUnaryOp(getCurScope(), LoopVarLoc, tok::star, NewLoopVarInit.get());
   if (DerefExpr.isInvalid()) {
     Diag(LoopVarLoc, diag::note_for_range_invalid_iterator)
         << LoopVarLoc << 1 << NewLoopVarInit.get()->getType();

--- a/clang/lib/Sema/SemaStmt.cpp
+++ b/clang/lib/Sema/SemaStmt.cpp
@@ -3507,12 +3507,16 @@ StmtResult Sema::ActOnCilkForRangeStmt(Scope *S, SourceLocation ForLoc, Stmt *In
                                       BuildForRangeKind Kind) {
   // we wrap the for range!
   SourceLocation EmptyCoawaitLoc;
-  StmtResult ForRangeStmt = this->ActOnCXXForRangeStmt(
+  StmtResult ForRangeStmt = ActOnCXXForRangeStmt(
       S, ForLoc, EmptyCoawaitLoc, InitStmt,
       First, ColonLoc, Range,
       RParenLoc, Kind);
 
-  return ForRangeStmt;
+  return BuildCilkForRangeStmt(ForRangeStmt);
+}
+
+StmtResult Sema::BuildCilkForRangeStmt(CXXForRangeStmt *ForRange) {
+  return new (Context) CilkForRangeStmt(Context, ForRange);
 }
 
 

--- a/clang/lib/Sema/SemaStmt.cpp
+++ b/clang/lib/Sema/SemaStmt.cpp
@@ -3498,6 +3498,9 @@ static void SearchForReturnInStmt(Sema &Self, Stmt *S) {
 
 // TODO: add comment
 StmtResult Sema::FinishCilkForRangeStmt(Stmt *S, Stmt *B) {
+  if (!S || !B)
+    return StmtError();
+
   CilkForRangeStmt *CilkForRange = cast<CilkForRangeStmt>(S);
 
   StmtResult ForRange = FinishCXXForRangeStmt(CilkForRange->getCXXForRangeStmt(), B);

--- a/clang/lib/Sema/SemaStmt.cpp
+++ b/clang/lib/Sema/SemaStmt.cpp
@@ -3508,7 +3508,7 @@ StmtResult Sema::ActOnCilkForRangeStmt(Scope *S, SourceLocation ForLoc, Stmt *In
   // we wrap the for range!
   SourceLocation EmptyCoawaitLoc;
   StmtResult ForRangeStmt = this->ActOnCXXForRangeStmt(
-      getCurScope(), ForLoc, EmptyCoawaitLoc, InitStmt,
+      S, ForLoc, EmptyCoawaitLoc, InitStmt,
       First, ColonLoc, Range,
       RParenLoc, Kind);
 

--- a/clang/lib/Sema/SemaStmt.cpp
+++ b/clang/lib/Sema/SemaStmt.cpp
@@ -3517,8 +3517,8 @@ StmtResult Sema::FinishCilkForRangeStmt(Stmt *S, Stmt *B) {
   ExprResult BeginRef = BuildDeclRefExpr(BeginVar, BeginRefNonRefType,
                                          VK_LValue, CXXForRange->getColonLoc());
 
-//  VarDecl *LoopIndex = CilkForRange->getLocalLoopIndex();
-  VarDecl *LoopIndex = CilkForRange->getLoopIndex();
+  VarDecl *LoopIndex = CilkForRange->getLocalLoopIndex();
+//  VarDecl *LoopIndex = CilkForRange->getLoopIndex();
   QualType LoopIndexType = LoopIndex->getType();
   const QualType LoopIndexRefNonRefType = LoopIndexType.getNonReferenceType();
   ExprResult LoopIndexRef = BuildDeclRefExpr(

--- a/clang/lib/Sema/SemaStmt.cpp
+++ b/clang/lib/Sema/SemaStmt.cpp
@@ -3496,6 +3496,26 @@ static void SearchForReturnInStmt(Sema &Self, Stmt *S) {
   }
 }
 
+// TODO: add comment
+StmtResult Sema::FinishCilkForRangeStmt(Stmt *S, Stmt *B) {
+  return this->FinishCXXForRangeStmt(S, B);
+}
+
+StmtResult Sema::ActOnCilkForRangeStmt(Scope *S, SourceLocation ForLoc, Stmt *InitStmt,
+                                      Stmt *First, SourceLocation ColonLoc,
+                                      Expr *Range, SourceLocation RParenLoc,
+                                      BuildForRangeKind Kind) {
+  // we wrap the for range!
+  SourceLocation EmptyCoawaitLoc;
+  StmtResult ForRangeStmt = this->ActOnCXXForRangeStmt(
+      getCurScope(), ForLoc, EmptyCoawaitLoc, InitStmt,
+      First, ColonLoc, Range,
+      RParenLoc, Kind);
+
+  return ForRangeStmt;
+}
+
+
 StmtResult
 Sema::ActOnCilkForStmt(SourceLocation CilkForLoc, SourceLocation LParenLoc,
                        Stmt *First, DeclStmt *Limit, ConditionResult InitCond,

--- a/clang/lib/Sema/SemaStmt.cpp
+++ b/clang/lib/Sema/SemaStmt.cpp
@@ -3518,7 +3518,6 @@ StmtResult Sema::FinishCilkForRangeStmt(Stmt *S, Stmt *B) {
                                          VK_LValue, CXXForRange->getColonLoc());
 
   VarDecl *LoopIndex = CilkForRange->getLocalLoopIndex();
-//  VarDecl *LoopIndex = CilkForRange->getLoopIndex();
   QualType LoopIndexType = LoopIndex->getType();
   const QualType LoopIndexRefNonRefType = LoopIndexType.getNonReferenceType();
   ExprResult LoopIndexRef = BuildDeclRefExpr(
@@ -3613,7 +3612,6 @@ StmtResult Sema::BuildCilkForRangeStmt(CXXForRangeStmt *ForRange) {
   if (LoopIndexStmt.isInvalid())
     return StmtError();
 
-
   ExprResult LimitRef =
       BuildDeclRefExpr(Limit, Limit->getType(), VK_LValue, RangeLoc);
   ExprResult LoopIndexRef =
@@ -3628,13 +3626,14 @@ StmtResult Sema::BuildCilkForRangeStmt(CXXForRangeStmt *ForRange) {
       BuildForRangeVarDecl(*this, RangeLoc, LimitExpr.get()->getType(),
                            std::string("__local_loopindex"));
   AddInitializerToDecl(LocalLoopIndex, LoopIndexRef.get(),
-      /*DirectInit=*/false);
+                       /*DirectInit=*/false);
   FinalizeDeclaration(LocalLoopIndex);
   CurContext->addHiddenDecl(LocalLoopIndex);
 
-  DeclGroupPtrTy LocalLoopIndexGroup =
-      BuildDeclaratorGroup(MutableArrayRef<Decl *>((Decl **)&LocalLoopIndex, 1));
-  StmtResult LocalLoopIndexStmt = ActOnDeclStmt(LocalLoopIndexGroup, RangeLoc, RangeLoc);
+  DeclGroupPtrTy LocalLoopIndexGroup = BuildDeclaratorGroup(
+      MutableArrayRef<Decl *>((Decl **)&LocalLoopIndex, 1));
+  StmtResult LocalLoopIndexStmt =
+      ActOnDeclStmt(LocalLoopIndexGroup, RangeLoc, RangeLoc);
   if (LocalLoopIndexStmt.isInvalid())
     return StmtError();
 
@@ -3647,8 +3646,9 @@ StmtResult Sema::BuildCilkForRangeStmt(CXXForRangeStmt *ForRange) {
     return StmtError();
 
   return new (Context) CilkForRangeStmt(
-      Context, ForRange, LoopIndex, cast<DeclStmt>(LocalLoopIndexStmt.get()), cast<DeclStmt>(LimitStmt.get()), Cond.get(),
-      NewInc.get(), cast<DeclStmt>(LoopIndexStmt.get()));
+      Context, ForRange, LoopIndex, cast<DeclStmt>(LocalLoopIndexStmt.get()),
+      cast<DeclStmt>(LimitStmt.get()), Cond.get(), NewInc.get(),
+      cast<DeclStmt>(LoopIndexStmt.get()));
 }
 
 StmtResult

--- a/clang/lib/Sema/SemaStmt.cpp
+++ b/clang/lib/Sema/SemaStmt.cpp
@@ -3516,7 +3516,7 @@ StmtResult Sema::FinishCilkForRangeStmt(Stmt *S, Stmt *B) {
   VarDecl *LoopIndex = CilkForRange->getLoopIndex();
   QualType LoopIndexType = LoopIndex->getType();
   const QualType LoopIndexRefNonRefType = LoopIndexType.getNonReferenceType();
-  ExprResult LoopIndexRef = BuildDeclRefExpr(BeginVar, LoopIndexRefNonRefType,
+  ExprResult LoopIndexRef = BuildDeclRefExpr(LoopIndex, LoopIndexRefNonRefType,
                                          VK_LValue, CXXForRange->getColonLoc());
 
 

--- a/clang/lib/Sema/SemaStmt.cpp
+++ b/clang/lib/Sema/SemaStmt.cpp
@@ -3562,9 +3562,9 @@ StmtResult Sema::BuildCilkForRangeStmt(CXXForRangeStmt *ForRange) {
                          LoopBoundExpr.get());
   if (Cond.isInvalid())
     return StmtError();
-  
 
-  return new (Context) CilkForRangeStmt(Context, ForRange, LoopVar, Cond);
+
+  return new (Context) CilkForRangeStmt(Context, ForRange, LoopVar, Cond.get());
 }
 
 

--- a/clang/lib/Sema/SemaStmt.cpp
+++ b/clang/lib/Sema/SemaStmt.cpp
@@ -3498,7 +3498,12 @@ static void SearchForReturnInStmt(Sema &Self, Stmt *S) {
 
 // TODO: add comment
 StmtResult Sema::FinishCilkForRangeStmt(Stmt *S, Stmt *B) {
-  return FinishCXXForRangeStmt(cast<CilkForRangeStmt>(S)->getCXXForRangeStmt(), B);
+  CilkForRangeStmt *CilkForRange = cast<CilkForRangeStmt>(S);
+  StmtResult ForRange = FinishCXXForRangeStmt(CilkForRange->getCXXForRangeStmt(), B);
+  if (ForRange.isInvalid())
+    return StmtError();
+  CilkForRange->setForRange(ForRange.get());
+  return CilkForRange;
 }
 
 StmtResult Sema::ActOnCilkForRangeStmt(Scope *S, SourceLocation ForLoc, Stmt *InitStmt,

--- a/clang/lib/Sema/SemaStmt.cpp
+++ b/clang/lib/Sema/SemaStmt.cpp
@@ -3498,7 +3498,7 @@ static void SearchForReturnInStmt(Sema &Self, Stmt *S) {
 
 // TODO: add comment
 StmtResult Sema::FinishCilkForRangeStmt(Stmt *S, Stmt *B) {
-  return this->FinishCXXForRangeStmt(S, B);
+  return FinishCXXForRangeStmt(cast<CilkForRangeStmt>(S)->getCXXForRangeStmt(), B);
 }
 
 StmtResult Sema::ActOnCilkForRangeStmt(Scope *S, SourceLocation ForLoc, Stmt *InitStmt,

--- a/clang/lib/Sema/SemaStmt.cpp
+++ b/clang/lib/Sema/SemaStmt.cpp
@@ -3586,6 +3586,12 @@ StmtResult Sema::BuildCilkForRangeStmt(CXXForRangeStmt *ForRange) {
   FinalizeDeclaration(LoopIndex);
   CurContext->addHiddenDecl(LoopIndex);
 
+  DeclGroupPtrTy LoopIndexGroup =
+      BuildDeclaratorGroup(MutableArrayRef<Decl *>((Decl **)&LoopIndex, 1));
+  StmtResult LoopIndexStmt = ActOnDeclStmt(LoopIndexGroup, RangeLoc, RangeLoc);
+  if (LoopIndexStmt.isInvalid())
+    return StmtError();
+
   ExprResult LoopIndexRef = BuildDeclRefExpr(LoopIndex, LoopIndex->getType(), VK_LValue,
                                          RangeLoc);
   ExprResult Cond;
@@ -3601,7 +3607,7 @@ StmtResult Sema::BuildCilkForRangeStmt(CXXForRangeStmt *ForRange) {
   if (NewInc.isInvalid())
     return StmtError();
 
-  return new (Context) CilkForRangeStmt(Context, ForRange, LoopIndex, Cond.get(), NewInc.get());
+  return new (Context) CilkForRangeStmt(Context, ForRange, LoopIndexStmt.get(), Cond.get(), NewInc.get(), cast<DeclStmt>(LoopIndexStmt.get()));
 }
 
 

--- a/clang/lib/Sema/SemaStmt.cpp
+++ b/clang/lib/Sema/SemaStmt.cpp
@@ -3512,7 +3512,10 @@ StmtResult Sema::ActOnCilkForRangeStmt(Scope *S, SourceLocation ForLoc, Stmt *In
       First, ColonLoc, Range,
       RParenLoc, Kind);
 
-  return BuildCilkForRangeStmt(ForRangeStmt);
+  if (ForRangeStmt.isInvalid())
+    return ForRangeStmt;
+
+  return BuildCilkForRangeStmt(cast_or_null<CXXForRangeStmt>(ForRangeStmt.get()));
 }
 
 StmtResult Sema::BuildCilkForRangeStmt(CXXForRangeStmt *ForRange) {

--- a/clang/lib/Sema/SemaStmt.cpp
+++ b/clang/lib/Sema/SemaStmt.cpp
@@ -3541,9 +3541,9 @@ StmtResult Sema::BuildCilkForRangeStmt(CXXForRangeStmt *ForRange) {
   ExprResult EndRef = BuildDeclRefExpr(EndVar, EndRefNonRefType,
                               VK_LValue, ForRange->getColonLoc());
   ExprResult LoopBoundExpr = ActOnBinOp(S, ForRange->getColonLoc(), tok::minus, EndRef.get(), BeginRef.get());
-  if (!LoopBoundExpr.isInvalid()) {
+  if (LoopBoundExpr.isInvalid()) {
     // give warning about for range only supporting random access!
-    Diag(ForRange->getForLoc(), diag::err_cilk_for_range_begin_minus_end);
+    Diag(ForRange->getForLoc(), diag::err_cilk_for_range_end_minus_begin);
     return StmtError();
   }
 

--- a/clang/lib/Sema/SemaStmtAttr.cpp
+++ b/clang/lib/Sema/SemaStmtAttr.cpp
@@ -87,9 +87,10 @@ static Attr *handleLoopHintAttr(Sema &S, Stmt *St, const ParsedAttr &A,
           .Default("clang loop");
 
   if ((PragmaName == "cilk") &&
-      (St->getStmtClass() != Stmt::CilkForStmtClass)) {
+      (St->getStmtClass() != Stmt::CilkForStmtClass &&
+       St->getStmtClass() != Stmt::CilkForRangeStmtClass)) {
     S.Diag(St->getBeginLoc(), diag::err_pragma_cilk_precedes_noncilk)
-      << "#pragma cilk";
+        << "#pragma cilk";
     return nullptr;
   }
 
@@ -97,7 +98,8 @@ static Attr *handleLoopHintAttr(Sema &S, Stmt *St, const ParsedAttr &A,
       St->getStmtClass() != Stmt::ForStmtClass &&
       St->getStmtClass() != Stmt::CXXForRangeStmtClass &&
       St->getStmtClass() != Stmt::WhileStmtClass &&
-      St->getStmtClass() != Stmt::CilkForStmtClass) {
+      St->getStmtClass() != Stmt::CilkForStmtClass &&
+      St->getStmtClass() != Stmt::CilkForRangeStmtClass) {
     std::string Pragma = "#pragma " + std::string(PragmaName);
     S.Diag(St->getBeginLoc(), diag::err_pragma_loop_precedes_nonloop) << Pragma;
     return nullptr;

--- a/clang/lib/Sema/TreeTransform.h
+++ b/clang/lib/Sema/TreeTransform.h
@@ -1368,6 +1368,14 @@ public:
                                       RParenLoc, Body, LoopVar);
   }
 
+  // Builds a new Cilk for range statement.
+  // TODO: this feels very hacky
+  StmtResult RebuildCilkForRangeStmt(CXXForRangeStmt *ForRange) {
+    // we don't reconstruct the for range into its constituent parts,
+    // but rather let the ForRange handle it for us
+    return getSema().BuildCilkForRangeStmt(ForRange);
+  }
+
   /// Build a new goto statement.
   ///
   /// By default, performs semantic analysis to build the new statement.
@@ -13859,6 +13867,16 @@ TreeTransform<Derived>::TransformCilkForStmt(CilkForStmt *S) {
       S->getCilkForLoc(), S->getLParenLoc(), Init.get(), Limit.get(),
       InitCond, Begin.get(), End.get(), Cond, FullInc, S->getRParenLoc(),
       LoopVar, Body.get());
+}
+
+template<typename Derived>
+StmtResult
+TreeTransform<Derived>::TransformCilkForRangeStmt(CilkForRangeStmt *S) {
+  CXXForRangeStmt ForRange = getDerived().TransformStmt(S->getCXXForRangeStmt());
+  if (ForRange.isInvalid())
+    return StmtError();
+
+  return getDerived().RebuildCilkForRangeStmt(ForRange.get());
 }
 
 } // end namespace clang

--- a/clang/lib/Sema/TreeTransform.h
+++ b/clang/lib/Sema/TreeTransform.h
@@ -1370,10 +1370,10 @@ public:
 
   // Builds a new Cilk for range statement.
   // TODO: this feels very hacky
-  StmtResult RebuildCilkForRangeStmt(CXXForRangeStmt *ForRange) {
+  StmtResult RebuildCilkForRangeStmt(Stmt *ForRange) {
     // we don't reconstruct the for range into its constituent parts,
     // but rather let the ForRange handle it for us
-    return getSema().BuildCilkForRangeStmt(ForRange);
+    return getSema().BuildCilkForRangeStmt(cast_or_null<CXXForRangeStmt>(ForRange));
   }
 
   /// Build a new goto statement.
@@ -13872,7 +13872,7 @@ TreeTransform<Derived>::TransformCilkForStmt(CilkForStmt *S) {
 template<typename Derived>
 StmtResult
 TreeTransform<Derived>::TransformCilkForRangeStmt(CilkForRangeStmt *S) {
-  CXXForRangeStmt ForRange = getDerived().TransformStmt(S->getCXXForRangeStmt());
+  StmtResult ForRange = getDerived().TransformStmt(S->getCXXForRangeStmt());
   if (ForRange.isInvalid())
     return StmtError();
 

--- a/clang/lib/Sema/TreeTransform.h
+++ b/clang/lib/Sema/TreeTransform.h
@@ -1368,12 +1368,16 @@ public:
                                       RParenLoc, Body, LoopVar);
   }
 
-  // Builds a new Cilk for range statement.
-  // TODO: this feels very hacky
+  /// Build a new Cilk for range statement.
+  ///
+  /// By default, performs semantic analysis to build the new statement.
+  /// Subclasses may override this routine to provide different behavior.
   StmtResult RebuildCilkForRangeStmt(Stmt *ForRange) {
-    // we don't reconstruct the for range into its constituent parts,
-    // but rather let the ForRange handle it for us
-    return getSema().BuildCilkForRangeStmt(cast_or_null<CXXForRangeStmt>(ForRange));
+    // We don't reconstruct the for range from its constituent parts,
+    // but rather let the CXXForRange do the rebuild, and then recompute
+    // all our fields by building it again.
+    return getSema().BuildCilkForRangeStmt(
+        cast_or_null<CXXForRangeStmt>(ForRange));
   }
 
   /// Build a new goto statement.

--- a/clang/lib/Sema/TreeTransform.h
+++ b/clang/lib/Sema/TreeTransform.h
@@ -1379,6 +1379,9 @@ public:
     return getSema().BuildCilkForRangeStmt(
         cast_or_null<CXXForRangeStmt>(ForRange));
   }
+  StmtResult FinishCilkForRangeStmt(Stmt *ForRange, Stmt *Body) {
+    return getSema().FinishCilkForRangeStmt(ForRange, Body);
+  }
 
   /// Build a new goto statement.
   ///
@@ -13880,7 +13883,13 @@ TreeTransform<Derived>::TransformCilkForRangeStmt(CilkForRangeStmt *S) {
   if (ForRange.isInvalid())
     return StmtError();
 
-  return getDerived().RebuildCilkForRangeStmt(ForRange.get());
+  StmtResult CilkForRange =
+      getDerived().RebuildCilkForRangeStmt(ForRange.get());
+  if (CilkForRange.isInvalid())
+    return StmtError();
+
+  return getDerived().FinishCilkForRangeStmt(
+      CilkForRange.get(), cast<CXXForRangeStmt>(ForRange.get())->getBody());
 }
 
 } // end namespace clang

--- a/clang/lib/Serialization/ASTReaderStmt.cpp
+++ b/clang/lib/Serialization/ASTReaderStmt.cpp
@@ -2793,6 +2793,10 @@ Stmt *ASTReader::ReadStmtFromStream(ModuleFile &F) {
       S = new (Context) CilkForStmt(Empty);
       break;
 
+    case STMT_CILKFORRANGE:
+      S = new (Context) CilkForRangeStmt(Empty);
+      break;
+
     case EXPR_PREDEFINED:
       S = PredefinedExpr::CreateEmpty(
           Context,

--- a/clang/lib/Serialization/ASTReaderStmt.cpp
+++ b/clang/lib/Serialization/ASTReaderStmt.cpp
@@ -2573,6 +2573,11 @@ void ASTStmtReader::VisitCilkForStmt(CilkForStmt *S) {
   S->setRParenLoc(readSourceLocation());
 }
 
+void ASTStmtReader::VisitCilkForRangeStmt(CilkForRangeStmt *S) {
+  VisitStmt(S);
+  S->setForRange(Record.readSubStmt());
+}
+
 //===----------------------------------------------------------------------===//
 // ASTReader Implementation
 //===----------------------------------------------------------------------===//

--- a/clang/lib/Serialization/ASTWriterStmt.cpp
+++ b/clang/lib/Serialization/ASTWriterStmt.cpp
@@ -2025,6 +2025,12 @@ void ASTStmtWriter::VisitCilkForStmt(CilkForStmt *S) {
   Code = serialization::STMT_CILKFOR;
 }
 
+void ASTStmtWriter::VisitCilkForRangeStmt(CilkForRangeStmt *S) {
+  VisitStmt(S);
+  Record.AddStmt(S->getCXXForRangeStmt());
+  Code = serialization::STMT_CILKFORRANGE;
+}
+
 //===----------------------------------------------------------------------===//
 // Microsoft Expressions and Statements.
 //===----------------------------------------------------------------------===//

--- a/clang/test/Cilk/cilkforrange-ir.cpp
+++ b/clang/test/Cilk/cilkforrange-ir.cpp
@@ -25,8 +25,7 @@ struct C {
 void bar(int i);
 
 void iterate(X::C c) {
-  _Cilk_for(int x
-            : c) // expected-warning {{'_Cilk_for' support for for-range loops is currently EXPERIMENTAL only!}}
+  _Cilk_for(int x : c) // expected-warning {{'_Cilk_for' support for for-range loops is currently EXPERIMENTAL only!}}
       bar(x);
 }
 
@@ -86,8 +85,7 @@ void iterate(X::C c) {
 // CHECK-NEXT: sync within %[[SYNCREG]]
 
 void iterate_ref(X::C c) {
-  _Cilk_for(int &x
-            : c) // expected-warning {{'_Cilk_for' support for for-range loops is currently EXPERIMENTAL only!}}
+  _Cilk_for(int &x : c) // expected-warning {{'_Cilk_for' support for for-range loops is currently EXPERIMENTAL only!}}
       bar(x);
 }
 
@@ -146,8 +144,7 @@ void iterate_ref(X::C c) {
 // CHECK-NEXT: sync within %[[SYNCREG]]
 
 void iterate_auto(X::C c) {
-  _Cilk_for(auto x
-            : c) // expected-warning {{'_Cilk_for' support for for-range loops is currently EXPERIMENTAL only!}}
+  _Cilk_for(auto x : c) // expected-warning {{'_Cilk_for' support for for-range loops is currently EXPERIMENTAL only!}}
       bar(x);
 }
 
@@ -207,8 +204,7 @@ void iterate_auto(X::C c) {
 // CHECK-NEXT: sync within %[[SYNCREG]]
 
 void iterate_autoref(X::C c) {
-  _Cilk_for(auto &x
-            : c) // expected-warning {{'_Cilk_for' support for for-range loops is currently EXPERIMENTAL only!}}
+  _Cilk_for(auto &x : c) // expected-warning {{'_Cilk_for' support for for-range loops is currently EXPERIMENTAL only!}}
       bar(x);
 }
 

--- a/clang/test/Cilk/cilkforrange-ir.cpp
+++ b/clang/test/Cilk/cilkforrange-ir.cpp
@@ -1,0 +1,267 @@
+// RUN: %clang_cc1 %s -std=c++11 -triple x86_64-unknown-linux-gnu -fopencilk -ftapir=none -verify -S -emit-llvm -o - | FileCheck %s
+//
+// useful command:
+//    ./clang++ -std=c++11 -fopencilk -ftapir=none -S -emit-llvm ../opencilk-project/clang/test/Cilk/cilkforrange-ir.cpp
+//    cat cilkforrange-ir.ll | grep Z2upN1 -C 50
+
+namespace X {
+struct C {
+  C();
+  struct It {
+    int value;
+    int operator-(It &);
+    It operator+(int);
+    It operator++();
+    It operator--();
+    int &operator*();
+    bool operator!=(It &);
+  };
+  It begin();
+  It end();
+};
+
+} // namespace X
+
+void bar(int i);
+
+void iterate(X::C c) {
+  _Cilk_for(int x
+            : c) // expected-warning {{'_Cilk_for' support for for-range loops is currently EXPERIMENTAL only!}}
+      bar(x);
+}
+
+// CHECK-LABEL: define void @_Z7iterateN1X1CE(
+
+// CHECK: %[[C:.+]] = alloca %"struct.X::C", align 1
+// CHECK-NEXT: %syncreg = call token @llvm.syncregion.start()
+// CHECK-NEXT: %[[RANGE:.+]] = alloca %"struct.X::C"*, align 8
+// CHECK-NEXT: %[[BEGIN:.+]] = alloca %"struct.X::C::It", align 4
+// CHECK-NEXT: %[[END:.+]] = alloca %"struct.X::C::It", align 4
+// CHECK-NEXT: %[[CILKLOOPINDEX:.+]] = alloca i32, align 4
+// CHECK-NEXT: %[[CILKLOOPLIMIT:.+]] = alloca i32, align 4
+// CHECK-NEXT: store %"struct.X::C"* %[[C]], %"struct.X::C"** %[[RANGE]], align 8
+// CHECK-NEXT: %[[CONTAINER:.+]] = load %"struct.X::C"*, %"struct.X::C"** %[[RANGE]], align 8
+// CHECK-NEXT: %[[BEGINCALL:.+]] = call i32 @_ZN1X1C5beginEv(%"struct.X::C"* %[[CONTAINER]])
+// CHECK-NEXT: %[[BEGINCOERCE:.+]] = getelementptr inbounds %"struct.X::C::It", %"struct.X::C::It"* %[[BEGIN]], i32 0, i32 0
+// CHECK-NEXT: store i32 %[[BEGINCALL]], i32* %[[BEGINCOERCE]], align 4
+// CHECK-NEXT: %[[CONTAINERAGAIN:.+]] = load %"struct.X::C"*, %"struct.X::C"** %[[RANGE]], align 8
+// CHECK-NEXT: %[[ENDCALL:.+]] = call i32 @_ZN1X1C3endEv(%"struct.X::C"* %[[CONTAINERAGAIN]])
+// CHECK-NEXT: %[[ENDCOERCE:.+]] = getelementptr inbounds %"struct.X::C::It", %"struct.X::C::It"* %[[END]], i32 0, i32 0
+// CHECK-NEXT: store i32 %[[ENDCALL]], i32* %[[ENDCOERCE]], align 4
+// CHECK-NEXT: store i32 0, i32* %[[CILKLOOPINDEX]], align 4
+// CHECK-NEXT: %[[CONTAINERLENGTH:.+]] = call i32 @_ZN1X1C2ItmiERS1_(%"struct.X::C::It"* %[[END]], %"struct.X::C::It"* dereferenceable(4) %[[BEGIN]])
+// CHECK-NEXT: store i32 %[[CONTAINERLENGTH]], i32* %[[CILKLOOPLIMIT]], align 4
+// CHECK-NEXT: br label %[[PFORCOND:.+]]
+
+// CHECK: [[PFORCOND]]:
+// CHECK-NEXT: br label %[[PFORDETACH:.+]]
+
+// CHECK: [[PFORDETACH]]:
+// CHECK-NEXT: %[[INITITER:.+]] = load i32, i32* %[[CILKLOOPINDEX]], align 4
+// CHECK-NEXT: detach within %[[SYNCREG:.+]], label %[[DETACHED:.+]], label %[[PFORINC:.+]]
+
+// CHECK: [[DETACHED]]:
+// CHECK-NEXT: %__local_loopindex = alloca i32, align 4
+// CHECK-NEXT: %[[X:.+]] = alloca i32, align 4
+// CHECK-NEXT: %[[ITER:.+]] = alloca %"struct.X::C::It", align 4
+// CHECK-NEXT: store i32 %[[INITITER]], i32* %__local_loopindex, align 4
+// CHECK-NEXT: %[[LOOPINDEXCOPY:.+]] = load i32, i32* %__local_loopindex, align 4
+// CHECK-NEXT: %[[ITERREF:.+]] = call i32 @_ZN1X1C2ItplEi(%"struct.X::C::It"* %[[BEGIN]], i32 %[[LOOPINDEXCOPY]])
+// CHECK-NEXT: %[[ITER2:.+]] = getelementptr inbounds %"struct.X::C::It", %"struct.X::C::It"* %[[ITER]], i32 0, i32 0
+// CHECK-NEXT: store i32 %[[ITERREF]], i32* %[[ITER2]], align 4
+// CHECK-NEXT: %[[ELEM:.+]] = call dereferenceable(4) i32* @_ZN1X1C2ItdeEv(%"struct.X::C::It"* %[[ITER]])
+// CHECK-NEXT: %[[ELEMVAL:.+]] = load i32, i32* %[[ELEM]], align 4
+// CHECK-NEXT: store i32 %[[ELEMVAL]], i32* %[[X]], align 4
+
+// CHECK: [[PFORINC]]:
+// CHECK-NEXT: %[[INCBEGIN:.+]] = load i32, i32* %[[CILKLOOPINDEX]], align 4
+// CHECK-NEXT: %[[INC:.+]] = add nsw i32 %[[INCBEGIN]], 1
+// CHECK-NEXT: store i32 %[[INC]], i32* %[[CILKLOOPINDEX]], align 4
+// CHECK-NEXT: %[[CONDBEGIN:.+]] = load i32, i32* %[[CILKLOOPINDEX]], align 4
+// CHECK-NEXT: %[[CONDEND:.+]] = load i32, i32* %[[CILKLOOPLIMIT]], align 4
+// CHECK-NEXT: %[[COND:.+]] = icmp ne i32 %[[CONDBEGIN]], %[[CONDEND]]
+// CHECK-NEXT: br i1 %[[COND]], label %{{.+}}, label %[[PFORCONDCLEANUP:.+]], !llvm.loop ![[LOOPMD:.+]]
+
+// CHECK: [[PFORCONDCLEANUP]]:
+// CHECK-NEXT: sync within %[[SYNCREG]]
+
+void iterate_ref(X::C c) {
+  _Cilk_for(int &x
+            : c) // expected-warning {{'_Cilk_for' support for for-range loops is currently EXPERIMENTAL only!}}
+      bar(x);
+}
+
+// CHECK-LABEL: define void @_Z11iterate_refN1X1CE(
+
+// CHECK: %[[C:.+]] = alloca %"struct.X::C", align 1
+// CHECK-NEXT: %syncreg = call token @llvm.syncregion.start()
+// CHECK-NEXT: %[[RANGE:.+]] = alloca %"struct.X::C"*, align 8
+// CHECK-NEXT: %[[BEGIN:.+]] = alloca %"struct.X::C::It", align 4
+// CHECK-NEXT: %[[END:.+]] = alloca %"struct.X::C::It", align 4
+// CHECK-NEXT: %[[CILKLOOPINDEX:.+]] = alloca i32, align 4
+// CHECK-NEXT: %[[CILKLOOPLIMIT:.+]] = alloca i32, align 4
+// CHECK-NEXT: store %"struct.X::C"* %[[C]], %"struct.X::C"** %[[RANGE]], align 8
+// CHECK-NEXT: %[[CONTAINER:.+]] = load %"struct.X::C"*, %"struct.X::C"** %[[RANGE]], align 8
+// CHECK-NEXT: %[[BEGINCALL:.+]] = call i32 @_ZN1X1C5beginEv(%"struct.X::C"* %[[CONTAINER]])
+// CHECK-NEXT: %[[BEGINCOERCE:.+]] = getelementptr inbounds %"struct.X::C::It", %"struct.X::C::It"* %[[BEGIN]], i32 0, i32 0
+// CHECK-NEXT: store i32 %[[BEGINCALL]], i32* %[[BEGINCOERCE]], align 4
+// CHECK-NEXT: %[[CONTAINERAGAIN:.+]] = load %"struct.X::C"*, %"struct.X::C"** %[[RANGE]], align 8
+// CHECK-NEXT: %[[ENDCALL:.+]] = call i32 @_ZN1X1C3endEv(%"struct.X::C"* %[[CONTAINERAGAIN]])
+// CHECK-NEXT: %[[ENDCOERCE:.+]] = getelementptr inbounds %"struct.X::C::It", %"struct.X::C::It"* %[[END]], i32 0, i32 0
+// CHECK-NEXT: store i32 %[[ENDCALL]], i32* %[[ENDCOERCE]], align 4
+// CHECK-NEXT: store i32 0, i32* %[[CILKLOOPINDEX]], align 4
+// CHECK-NEXT: %[[CONTAINERLENGTH:.+]] = call i32 @_ZN1X1C2ItmiERS1_(%"struct.X::C::It"* %[[END]], %"struct.X::C::It"* dereferenceable(4) %[[BEGIN]])
+// CHECK-NEXT: store i32 %[[CONTAINERLENGTH]], i32* %[[CILKLOOPLIMIT]], align 4
+// CHECK-NEXT: br label %[[PFORCOND:.+]]
+
+// CHECK: [[PFORCOND]]:
+// CHECK-NEXT: br label %[[PFORDETACH:.+]]
+
+// CHECK: [[PFORDETACH]]:
+// CHECK-NEXT: %[[INITITER:.+]] = load i32, i32* %[[CILKLOOPINDEX]], align 4
+// CHECK-NEXT: detach within %[[SYNCREG:.+]], label %[[DETACHED:.+]], label %[[PFORINC:.+]]
+
+// CHECK: [[DETACHED]]:
+// CHECK-NEXT: %__local_loopindex = alloca i32, align 4
+// CHECK-NEXT: %[[X:.+]] = alloca i32*, align 8
+// CHECK-NEXT: %[[ITER:.+]] = alloca %"struct.X::C::It", align 4
+// CHECK-NEXT: store i32 %[[INITITER]], i32* %__local_loopindex, align 4
+// CHECK-NEXT: %[[LOOPINDEXCOPY:.+]] = load i32, i32* %__local_loopindex, align 4
+// CHECK-NEXT: %[[ITERREF:.+]] = call i32 @_ZN1X1C2ItplEi(%"struct.X::C::It"* %[[BEGIN]], i32 %[[LOOPINDEXCOPY]])
+// CHECK-NEXT: %[[ITER2:.+]] = getelementptr inbounds %"struct.X::C::It", %"struct.X::C::It"* %[[ITER]], i32 0, i32 0
+// CHECK-NEXT: store i32 %[[ITERREF]], i32* %[[ITER2]], align 4
+// CHECK-NEXT: %[[ELEM:.+]] = call dereferenceable(4) i32* @_ZN1X1C2ItdeEv(%"struct.X::C::It"* %[[ITER]])
+// CHECK-NEXT: store i32* %[[ELEM]], i32** %[[X]], align 8
+
+// CHECK: [[PFORINC]]:
+// CHECK-NEXT: %[[INCBEGIN:.+]] = load i32, i32* %[[CILKLOOPINDEX]], align 4
+// CHECK-NEXT: %[[INC:.+]] = add nsw i32 %[[INCBEGIN]], 1
+// CHECK-NEXT: store i32 %[[INC]], i32* %[[CILKLOOPINDEX]], align 4
+// CHECK-NEXT: %[[CONDBEGIN:.+]] = load i32, i32* %[[CILKLOOPINDEX]], align 4
+// CHECK-NEXT: %[[CONDEND:.+]] = load i32, i32* %[[CILKLOOPLIMIT]], align 4
+// CHECK-NEXT: %[[COND:.+]] = icmp ne i32 %[[CONDBEGIN]], %[[CONDEND]]
+// CHECK-NEXT: br i1 %[[COND]], label %{{.+}}, label %[[PFORCONDCLEANUP:.+]], !llvm.loop ![[LOOPMD:.+]]
+
+// CHECK: [[PFORCONDCLEANUP]]:
+// CHECK-NEXT: sync within %[[SYNCREG]]
+
+void iterate_auto(X::C c) {
+  _Cilk_for(auto x
+            : c) // expected-warning {{'_Cilk_for' support for for-range loops is currently EXPERIMENTAL only!}}
+      bar(x);
+}
+
+// CHECK-LABEL: define void @_Z12iterate_autoN1X1CE(
+
+// CHECK: %[[C:.+]] = alloca %"struct.X::C", align 1
+// CHECK-NEXT: %syncreg = call token @llvm.syncregion.start()
+// CHECK-NEXT: %[[RANGE:.+]] = alloca %"struct.X::C"*, align 8
+// CHECK-NEXT: %[[BEGIN:.+]] = alloca %"struct.X::C::It", align 4
+// CHECK-NEXT: %[[END:.+]] = alloca %"struct.X::C::It", align 4
+// CHECK-NEXT: %[[CILKLOOPINDEX:.+]] = alloca i32, align 4
+// CHECK-NEXT: %[[CILKLOOPLIMIT:.+]] = alloca i32, align 4
+// CHECK-NEXT: store %"struct.X::C"* %[[C]], %"struct.X::C"** %[[RANGE]], align 8
+// CHECK-NEXT: %[[CONTAINER:.+]] = load %"struct.X::C"*, %"struct.X::C"** %[[RANGE]], align 8
+// CHECK-NEXT: %[[BEGINCALL:.+]] = call i32 @_ZN1X1C5beginEv(%"struct.X::C"* %[[CONTAINER]])
+// CHECK-NEXT: %[[BEGINCOERCE:.+]] = getelementptr inbounds %"struct.X::C::It", %"struct.X::C::It"* %[[BEGIN]], i32 0, i32 0
+// CHECK-NEXT: store i32 %[[BEGINCALL]], i32* %[[BEGINCOERCE]], align 4
+// CHECK-NEXT: %[[CONTAINERAGAIN:.+]] = load %"struct.X::C"*, %"struct.X::C"** %[[RANGE]], align 8
+// CHECK-NEXT: %[[ENDCALL:.+]] = call i32 @_ZN1X1C3endEv(%"struct.X::C"* %[[CONTAINERAGAIN]])
+// CHECK-NEXT: %[[ENDCOERCE:.+]] = getelementptr inbounds %"struct.X::C::It", %"struct.X::C::It"* %[[END]], i32 0, i32 0
+// CHECK-NEXT: store i32 %[[ENDCALL]], i32* %[[ENDCOERCE]], align 4
+// CHECK-NEXT: store i32 0, i32* %[[CILKLOOPINDEX]], align 4
+// CHECK-NEXT: %[[CONTAINERLENGTH:.+]] = call i32 @_ZN1X1C2ItmiERS1_(%"struct.X::C::It"* %[[END]], %"struct.X::C::It"* dereferenceable(4) %[[BEGIN]])
+// CHECK-NEXT: store i32 %[[CONTAINERLENGTH]], i32* %[[CILKLOOPLIMIT]], align 4
+// CHECK-NEXT: br label %[[PFORCOND:.+]]
+
+// CHECK: [[PFORCOND]]:
+// CHECK-NEXT: br label %[[PFORDETACH:.+]]
+
+// CHECK: [[PFORDETACH]]:
+// CHECK-NEXT: %[[INITITER:.+]] = load i32, i32* %[[CILKLOOPINDEX]], align 4
+// CHECK-NEXT: detach within %[[SYNCREG:.+]], label %[[DETACHED:.+]], label %[[PFORINC:.+]]
+
+// CHECK: [[DETACHED]]:
+// CHECK-NEXT: %__local_loopindex = alloca i32, align 4
+// CHECK-NEXT: %[[X:.+]] = alloca i32, align 4
+// CHECK-NEXT: %[[ITER:.+]] = alloca %"struct.X::C::It", align 4
+// CHECK-NEXT: store i32 %[[INITITER]], i32* %__local_loopindex, align 4
+// CHECK-NEXT: %[[LOOPINDEXCOPY:.+]] = load i32, i32* %__local_loopindex, align 4
+// CHECK-NEXT: %[[ITERREF:.+]] = call i32 @_ZN1X1C2ItplEi(%"struct.X::C::It"* %[[BEGIN]], i32 %[[LOOPINDEXCOPY]])
+// CHECK-NEXT: %[[ITER2:.+]] = getelementptr inbounds %"struct.X::C::It", %"struct.X::C::It"* %[[ITER]], i32 0, i32 0
+// CHECK-NEXT: store i32 %[[ITERREF]], i32* %[[ITER2]], align 4
+// CHECK-NEXT: %[[ELEM:.+]] = call dereferenceable(4) i32* @_ZN1X1C2ItdeEv(%"struct.X::C::It"* %[[ITER]])
+// CHECK-NEXT: %[[ELEMVAL:.+]] = load i32, i32* %[[ELEM]], align 4
+// CHECK-NEXT: store i32 %[[ELEMVAL]], i32* %[[X]], align 4
+
+// CHECK: [[PFORINC]]:
+// CHECK-NEXT: %[[INCBEGIN:.+]] = load i32, i32* %[[CILKLOOPINDEX]], align 4
+// CHECK-NEXT: %[[INC:.+]] = add nsw i32 %[[INCBEGIN]], 1
+// CHECK-NEXT: store i32 %[[INC]], i32* %[[CILKLOOPINDEX]], align 4
+// CHECK-NEXT: %[[CONDBEGIN:.+]] = load i32, i32* %[[CILKLOOPINDEX]], align 4
+// CHECK-NEXT: %[[CONDEND:.+]] = load i32, i32* %[[CILKLOOPLIMIT]], align 4
+// CHECK-NEXT: %[[COND:.+]] = icmp ne i32 %[[CONDBEGIN]], %[[CONDEND]]
+// CHECK-NEXT: br i1 %[[COND]], label %{{.+}}, label %[[PFORCONDCLEANUP:.+]], !llvm.loop ![[LOOPMD:.+]]
+
+// CHECK: [[PFORCONDCLEANUP]]:
+// CHECK-NEXT: sync within %[[SYNCREG]]
+
+void iterate_autoref(X::C c) {
+  _Cilk_for(auto &x
+            : c) // expected-warning {{'_Cilk_for' support for for-range loops is currently EXPERIMENTAL only!}}
+      bar(x);
+}
+
+// CHECK-LABEL: define void @_Z15iterate_autorefN1X1CE(
+
+// CHECK: %[[C:.+]] = alloca %"struct.X::C", align 1
+// CHECK-NEXT: %syncreg = call token @llvm.syncregion.start()
+// CHECK-NEXT: %[[RANGE:.+]] = alloca %"struct.X::C"*, align 8
+// CHECK-NEXT: %[[BEGIN:.+]] = alloca %"struct.X::C::It", align 4
+// CHECK-NEXT: %[[END:.+]] = alloca %"struct.X::C::It", align 4
+// CHECK-NEXT: %[[CILKLOOPINDEX:.+]] = alloca i32, align 4
+// CHECK-NEXT: %[[CILKLOOPLIMIT:.+]] = alloca i32, align 4
+// CHECK-NEXT: store %"struct.X::C"* %[[C]], %"struct.X::C"** %[[RANGE]], align 8
+// CHECK-NEXT: %[[CONTAINER:.+]] = load %"struct.X::C"*, %"struct.X::C"** %[[RANGE]], align 8
+// CHECK-NEXT: %[[BEGINCALL:.+]] = call i32 @_ZN1X1C5beginEv(%"struct.X::C"* %[[CONTAINER]])
+// CHECK-NEXT: %[[BEGINCOERCE:.+]] = getelementptr inbounds %"struct.X::C::It", %"struct.X::C::It"* %[[BEGIN]], i32 0, i32 0
+// CHECK-NEXT: store i32 %[[BEGINCALL]], i32* %[[BEGINCOERCE]], align 4
+// CHECK-NEXT: %[[CONTAINERAGAIN:.+]] = load %"struct.X::C"*, %"struct.X::C"** %[[RANGE]], align 8
+// CHECK-NEXT: %[[ENDCALL:.+]] = call i32 @_ZN1X1C3endEv(%"struct.X::C"* %[[CONTAINERAGAIN]])
+// CHECK-NEXT: %[[ENDCOERCE:.+]] = getelementptr inbounds %"struct.X::C::It", %"struct.X::C::It"* %[[END]], i32 0, i32 0
+// CHECK-NEXT: store i32 %[[ENDCALL]], i32* %[[ENDCOERCE]], align 4
+// CHECK-NEXT: store i32 0, i32* %[[CILKLOOPINDEX]], align 4
+// CHECK-NEXT: %[[CONTAINERLENGTH:.+]] = call i32 @_ZN1X1C2ItmiERS1_(%"struct.X::C::It"* %[[END]], %"struct.X::C::It"* dereferenceable(4) %[[BEGIN]])
+// CHECK-NEXT: store i32 %[[CONTAINERLENGTH]], i32* %[[CILKLOOPLIMIT]], align 4
+// CHECK-NEXT: br label %[[PFORCOND:.+]]
+
+// CHECK: [[PFORCOND]]:
+// CHECK-NEXT: br label %[[PFORDETACH:.+]]
+
+// CHECK: [[PFORDETACH]]:
+// CHECK-NEXT: %[[INITITER:.+]] = load i32, i32* %[[CILKLOOPINDEX]], align 4
+// CHECK-NEXT: detach within %[[SYNCREG:.+]], label %[[DETACHED:.+]], label %[[PFORINC:.+]]
+
+// CHECK: [[DETACHED]]:
+// CHECK-NEXT: %__local_loopindex = alloca i32, align 4
+// CHECK-NEXT: %[[X:.+]] = alloca i32*, align 8
+// CHECK-NEXT: %[[ITER:.+]] = alloca %"struct.X::C::It", align 4
+// CHECK-NEXT: store i32 %[[INITITER]], i32* %__local_loopindex, align 4
+// CHECK-NEXT: %[[LOOPINDEXCOPY:.+]] = load i32, i32* %__local_loopindex, align 4
+// CHECK-NEXT: %[[ITERREF:.+]] = call i32 @_ZN1X1C2ItplEi(%"struct.X::C::It"* %[[BEGIN]], i32 %[[LOOPINDEXCOPY]])
+// CHECK-NEXT: %[[ITER2:.+]] = getelementptr inbounds %"struct.X::C::It", %"struct.X::C::It"* %[[ITER]], i32 0, i32 0
+// CHECK-NEXT: store i32 %[[ITERREF]], i32* %[[ITER2]], align 4
+// CHECK-NEXT: %[[ELEM:.+]] = call dereferenceable(4) i32* @_ZN1X1C2ItdeEv(%"struct.X::C::It"* %[[ITER]])
+// CHECK-NEXT: store i32* %[[ELEM]], i32** %[[X]], align 8
+
+// CHECK: [[PFORINC]]:
+// CHECK-NEXT: %[[INCBEGIN:.+]] = load i32, i32* %[[CILKLOOPINDEX]], align 4
+// CHECK-NEXT: %[[INC:.+]] = add nsw i32 %[[INCBEGIN]], 1
+// CHECK-NEXT: store i32 %[[INC]], i32* %[[CILKLOOPINDEX]], align 4
+// CHECK-NEXT: %[[CONDBEGIN:.+]] = load i32, i32* %[[CILKLOOPINDEX]], align 4
+// CHECK-NEXT: %[[CONDEND:.+]] = load i32, i32* %[[CILKLOOPLIMIT]], align 4
+// CHECK-NEXT: %[[COND:.+]] = icmp ne i32 %[[CONDBEGIN]], %[[CONDEND]]
+// CHECK-NEXT: br i1 %[[COND]], label %{{.+}}, label %[[PFORCONDCLEANUP:.+]], !llvm.loop ![[LOOPMD:.+]]
+
+// CHECK: [[PFORCONDCLEANUP]]:
+// CHECK-NEXT: sync within %[[SYNCREG]]

--- a/clang/test/Cilk/rangelooptest.cpp
+++ b/clang/test/Cilk/rangelooptest.cpp
@@ -53,52 +53,42 @@ int Cilk_for_range_tests(int n) {
   for (int i = 0; i < n; i++)
     v[i] = i;
 
-  _Cilk_for(auto x
-            : v); // expected-warning {{range-based for loop has empty body}} expected-warning {{Cilk for loop has empty body}} expected-warning {{'_Cilk_for' support for for-range loops is currently EXPERIMENTAL only!}}
-  _Cilk_for(auto &x
-            : v); // expected-warning {{range-based for loop has empty body}} expected-warning {{Cilk for loop has empty body}} expected-warning {{'_Cilk_for' support for for-range loops is currently EXPERIMENTAL only!}}
-  _Cilk_for(int x
-            : v); // expected-warning {{range-based for loop has empty body}} expected-warning {{Cilk for loop has empty body}} expected-warning {{'_Cilk_for' support for for-range loops is currently EXPERIMENTAL only!}}
-  _Cilk_for(StdMock::Empty x
-            : v); // expected-warning {{range-based for loop has empty body}} expected-warning {{Cilk for loop has empty body}} expected-error {{no viable conversion from 'int' to 'StdMock::Empty'}}       expected-warning {{'_Cilk_for' support for for-range loops is currently EXPERIMENTAL only!}}
+  _Cilk_for(auto x : v); // expected-warning {{range-based for loop has empty body}} expected-warning {{Cilk for loop has empty body}} expected-warning {{'_Cilk_for' support for for-range loops is currently EXPERIMENTAL only!}}
+  _Cilk_for(auto &x : v); // expected-warning {{range-based for loop has empty body}} expected-warning {{Cilk for loop has empty body}} expected-warning {{'_Cilk_for' support for for-range loops is currently EXPERIMENTAL only!}}
+  _Cilk_for(int x : v); // expected-warning {{range-based for loop has empty body}} expected-warning {{Cilk for loop has empty body}} expected-warning {{'_Cilk_for' support for for-range loops is currently EXPERIMENTAL only!}}
+  _Cilk_for(StdMock::Empty x : v); // expected-warning {{range-based for loop has empty body}} expected-warning {{Cilk for loop has empty body}} expected-error {{no viable conversion from 'int' to 'StdMock::Empty'}}       expected-warning {{'_Cilk_for' support for for-range loops is currently EXPERIMENTAL only!}}
 
   // Pairs are aggregate types, which initially had a bug. Assert that they work
   StdMock::Vector<StdMock::Pair<int, int>> vp(n);
   for (int i = 0; i < n; i++) {
     vp[i] = {i, i + 1};
   }
-  _Cilk_for(auto p
-            : vp) // expected-warning {{'_Cilk_for' support for for-range loops is currently EXPERIMENTAL only!}}
+  _Cilk_for(auto p : vp) // expected-warning {{'_Cilk_for' support for for-range loops is currently EXPERIMENTAL only!}}
       continue;
-  _Cilk_for(auto &p
-            : vp) { // expected-warning {{'_Cilk_for' support for for-range loops is currently EXPERIMENTAL only!}}
+  _Cilk_for(auto &p : vp) { // expected-warning {{'_Cilk_for' support for for-range loops is currently EXPERIMENTAL only!}}
     continue;
   }
 
   int a[5];
-  _Cilk_for(int x
-            : a) // expected-warning {{'_Cilk_for' support for for-range loops is currently EXPERIMENTAL only!}}
+  _Cilk_for(int x : a) // expected-warning {{'_Cilk_for' support for for-range loops is currently EXPERIMENTAL only!}}
       continue;
 
   StdMock::Set<int> s(n);
-  _Cilk_for(int x
-            : s); // expected-error {{Cannot determine length with '__end - __begin'. Please use a random access iterator.}} expected-error {{invalid operands to binary expression ('StdMock::Set<int>::It' and 'StdMock::Set<int>::It')}} expected-warning {{'_Cilk_for' support for for-range loops is currently EXPERIMENTAL only!}}
+  _Cilk_for(int x : s); // expected-error {{Cannot determine length with '__end - __begin'. Please use a random access iterator.}} expected-error {{invalid operands to binary expression ('StdMock::Set<int>::It' and 'StdMock::Set<int>::It')}} expected-warning {{'_Cilk_for' support for for-range loops is currently EXPERIMENTAL only!}}
 
   // Check for return statements, which cannot appear anywhere in the body of a
   // _Cilk_for loop.
-  _Cilk_for(int i
-            : v) return 7; // expected-error{{cannot return}} expected-warning {{'_Cilk_for' support for for-range loops is currently EXPERIMENTAL only!}}
-  _Cilk_for(int i
-            : v)                            // expected-warning {{'_Cilk_for' support for for-range loops is currently EXPERIMENTAL only!}}
-      for (int j = 1; j < i; ++j) return 7; // expected-error{{cannot return}}
+  _Cilk_for(int i : v) return 7; // expected-error{{cannot return}} expected-warning {{'_Cilk_for' support for for-range loops is currently EXPERIMENTAL only!}}
+  _Cilk_for(int i : v) // expected-warning {{'_Cilk_for' support for for-range loops is currently EXPERIMENTAL only!}}
+      for (int j = 1; j < i; ++j)
+          return 7; // expected-error{{cannot return}}
 
   // Check for illegal break statements, which cannot bind to the scope of a
   // _Cilk_for loop, but can bind to loops nested within.
-  _Cilk_for(int i
-            : v) break; // expected-error{{cannot break}} expected-warning {{'_Cilk_for' support for for-range loops is currently EXPERIMENTAL only!}}
-  _Cilk_for(int i
-            : v) // expected-warning {{'_Cilk_for' support for for-range loops is currently EXPERIMENTAL only!}}
-      for (int j = 1; j < i; ++j) break;
+  _Cilk_for(int i : v) break; // expected-error{{cannot break}} expected-warning {{'_Cilk_for' support for for-range loops is currently EXPERIMENTAL only!}}
+  _Cilk_for(int i : v) // expected-warning {{'_Cilk_for' support for for-range loops is currently EXPERIMENTAL only!}}
+      for (int j = 1; j < i; ++j)
+          break;
 
   return 0;
 }
@@ -109,24 +99,20 @@ int range_pragma_tests(int n) {
     v[i] = i;
 
 #pragma clang loop unroll_count(4)
-  _Cilk_for(auto i
-            : v) // expected-warning {{'_Cilk_for' support for for-range loops is currently EXPERIMENTAL only!}}
+  _Cilk_for(auto i : v) // expected-warning {{'_Cilk_for' support for for-range loops is currently EXPERIMENTAL only!}}
       foo(i);
 
 #pragma cilk grainsize(4)
-  _Cilk_for(int i
-            : v) // expected-warning {{'_Cilk_for' support for for-range loops is currently EXPERIMENTAL only!}}
+  _Cilk_for(int i : v) // expected-warning {{'_Cilk_for' support for for-range loops is currently EXPERIMENTAL only!}}
       foo(i);
 
 #pragma cilk grainsize 4
-  _Cilk_for(auto i
-            : v) // expected-warning {{'_Cilk_for' support for for-range loops is currently EXPERIMENTAL only!}}
+  _Cilk_for(auto i : v) // expected-warning {{'_Cilk_for' support for for-range loops is currently EXPERIMENTAL only!}}
       foo(i);
 
 #pragma cilk grainsize = 4
   // expected-warning{{'#pragma cilk grainsize' no longer requires '='}}
-  _Cilk_for(int i
-            : v) // expected-warning {{'_Cilk_for' support for for-range loops is currently EXPERIMENTAL only!}}
+  _Cilk_for(int i : v) // expected-warning {{'_Cilk_for' support for for-range loops is currently EXPERIMENTAL only!}}
       foo(i);
 
   return 0;
@@ -137,8 +123,7 @@ int range_scope_tests(int n) {
   for (int i = 0; i < n; i++)
     v[i] = i;
   int A[5];
-  _Cilk_for(int i
-            : v) { // expected-warning {{'_Cilk_for' support for for-range loops is currently EXPERIMENTAL only!}}
+  _Cilk_for(int i : v) { // expected-warning {{'_Cilk_for' support for for-range loops is currently EXPERIMENTAL only!}}
     int A[5];
     A[i % 5] = i;
   }

--- a/clang/test/Cilk/rangelooptest.cpp
+++ b/clang/test/Cilk/rangelooptest.cpp
@@ -110,8 +110,7 @@ int range_pragma_tests(int n) {
   _Cilk_for(auto i : v) // expected-warning {{'_Cilk_for' support for for-range loops is currently EXPERIMENTAL only!}}
       foo(i);
 
-#pragma cilk grainsize = 4
-  // expected-warning{{'#pragma cilk grainsize' no longer requires '='}}
+#pragma cilk grainsize = 4 // expected-warning{{'#pragma cilk grainsize' no longer requires '='}}
   _Cilk_for(int i : v) // expected-warning {{'_Cilk_for' support for for-range loops is currently EXPERIMENTAL only!}}
       foo(i);
 

--- a/clang/test/Cilk/rangelooptest.cpp
+++ b/clang/test/Cilk/rangelooptest.cpp
@@ -1,0 +1,149 @@
+// RUN: %clang_cc1 -std=c++17 -verify -verify-ignore-unexpected=note %s
+
+namespace StdMock {
+template <class T>
+struct Vector {
+  T *arr;
+  Vector(int n) {
+    // malloc
+  }
+  struct It {
+    T value;
+    int operator-(It &);
+    It operator+(int);
+    It operator++();
+    It operator--();
+    T &operator*();
+    bool operator!=(It &);
+  };
+  It begin();
+  It end();
+  T &operator[](int i) {
+    return arr[i];
+  }
+};
+template <class T>
+struct Set {
+  T *set;
+  Set(int n) {
+    // malloc
+  }
+  struct It {
+    T value;
+    It operator++();
+    It operator--();
+    T &operator*();
+    bool operator!=(It &);
+  };
+  It begin();
+  It end();
+};
+struct Empty {};
+template <class T, class U>
+struct Pair {
+  T first;
+  U second;
+};
+} // namespace StdMock
+
+int foo(int n);
+
+int Cilk_for_range_tests(int n) {
+  StdMock::Vector<int> v(n);
+  for (int i = 0; i < n; i++)
+    v[i] = i;
+
+  _Cilk_for(auto x
+            : v); // expected-warning {{range-based for loop has empty body}} expected-warning {{Cilk for loop has empty body}} expected-warning {{'_Cilk_for' support for for-range loops is currently EXPERIMENTAL only!}}
+  _Cilk_for(auto &x
+            : v); // expected-warning {{range-based for loop has empty body}} expected-warning {{Cilk for loop has empty body}} expected-warning {{'_Cilk_for' support for for-range loops is currently EXPERIMENTAL only!}}
+  _Cilk_for(int x
+            : v); // expected-warning {{range-based for loop has empty body}} expected-warning {{Cilk for loop has empty body}} expected-warning {{'_Cilk_for' support for for-range loops is currently EXPERIMENTAL only!}}
+  _Cilk_for(StdMock::Empty x
+            : v); // expected-warning {{range-based for loop has empty body}} expected-warning {{Cilk for loop has empty body}} expected-error {{no viable conversion from 'int' to 'StdMock::Empty'}}       expected-warning {{'_Cilk_for' support for for-range loops is currently EXPERIMENTAL only!}}
+
+  // Pairs are aggregate types, which initially had a bug. Assert that they work
+  StdMock::Vector<StdMock::Pair<int, int>> vp(n);
+  for (int i = 0; i < n; i++) {
+    vp[i] = {i, i + 1};
+  }
+  _Cilk_for(auto p
+            : vp) // expected-warning {{'_Cilk_for' support for for-range loops is currently EXPERIMENTAL only!}}
+      continue;
+  _Cilk_for(auto &p
+            : vp) { // expected-warning {{'_Cilk_for' support for for-range loops is currently EXPERIMENTAL only!}}
+    continue;
+  }
+
+  int a[5];
+  _Cilk_for(int x
+            : a) // expected-warning {{'_Cilk_for' support for for-range loops is currently EXPERIMENTAL only!}}
+      continue;
+
+  StdMock::Set<int> s(n);
+  _Cilk_for(int x
+            : s); // expected-error {{Cannot determine length with '__end - __begin'. Please use a random access iterator.}} expected-error {{invalid operands to binary expression ('StdMock::Set<int>::It' and 'StdMock::Set<int>::It')}} expected-warning {{'_Cilk_for' support for for-range loops is currently EXPERIMENTAL only!}}
+
+  // Check for return statements, which cannot appear anywhere in the body of a
+  // _Cilk_for loop.
+  _Cilk_for(int i
+            : v) return 7; // expected-error{{cannot return}} expected-warning {{'_Cilk_for' support for for-range loops is currently EXPERIMENTAL only!}}
+  _Cilk_for(int i
+            : v)                            // expected-warning {{'_Cilk_for' support for for-range loops is currently EXPERIMENTAL only!}}
+      for (int j = 1; j < i; ++j) return 7; // expected-error{{cannot return}}
+
+  // Check for illegal break statements, which cannot bind to the scope of a
+  // _Cilk_for loop, but can bind to loops nested within.
+  _Cilk_for(int i
+            : v) break; // expected-error{{cannot break}} expected-warning {{'_Cilk_for' support for for-range loops is currently EXPERIMENTAL only!}}
+  _Cilk_for(int i
+            : v) // expected-warning {{'_Cilk_for' support for for-range loops is currently EXPERIMENTAL only!}}
+      for (int j = 1; j < i; ++j) break;
+
+  return 0;
+}
+
+int range_pragma_tests(int n) {
+  StdMock::Vector<int> v(n);
+  for (int i = 0; i < n; i++)
+    v[i] = i;
+
+#pragma clang loop unroll_count(4)
+  _Cilk_for(auto i
+            : v) // expected-warning {{'_Cilk_for' support for for-range loops is currently EXPERIMENTAL only!}}
+      foo(i);
+
+#pragma cilk grainsize(4)
+  _Cilk_for(int i
+            : v) // expected-warning {{'_Cilk_for' support for for-range loops is currently EXPERIMENTAL only!}}
+      foo(i);
+
+#pragma cilk grainsize 4
+  _Cilk_for(auto i
+            : v) // expected-warning {{'_Cilk_for' support for for-range loops is currently EXPERIMENTAL only!}}
+      foo(i);
+
+#pragma cilk grainsize = 4
+  // expected-warning{{'#pragma cilk grainsize' no longer requires '='}}
+  _Cilk_for(int i
+            : v) // expected-warning {{'_Cilk_for' support for for-range loops is currently EXPERIMENTAL only!}}
+      foo(i);
+
+  return 0;
+}
+
+int range_scope_tests(int n) {
+  StdMock::Vector<int> v(n);
+  for (int i = 0; i < n; i++)
+    v[i] = i;
+  int A[5];
+  _Cilk_for(int i
+            : v) { // expected-warning {{'_Cilk_for' support for for-range loops is currently EXPERIMENTAL only!}}
+    int A[5];
+    A[i % 5] = i;
+  }
+  for (int i : v) {
+    A[i % 5] = i % 5;
+  }
+  return 0;
+}

--- a/clang/tools/libclang/CIndex.cpp
+++ b/clang/tools/libclang/CIndex.cpp
@@ -5584,6 +5584,8 @@ CXString clang_getCursorKindSpelling(enum CXCursorKind Kind) {
     return cxstring::createRef("CilkSyncStmt");
   case CXCursor_CilkForStmt:
     return cxstring::createRef("CilkForStmt");
+  case CXCursor_CilkForRangeStmt:
+    return cxstring::createRef("CilkForRangeStmt");
   }
 
   llvm_unreachable("Unhandled CXCursorKind");

--- a/clang/tools/libclang/CXCursor.cpp
+++ b/clang/tools/libclang/CXCursor.cpp
@@ -266,6 +266,10 @@ CXCursor cxcursor::MakeCXCursor(const Stmt *S, const Decl *Parent,
     K = CXCursor_CilkForStmt;
     break;
 
+  case Stmt::CilkForRangeStmtClass:
+    K = CXCursor_CilkForRangeStmt;
+    break;
+
   case Stmt::ArrayTypeTraitExprClass:
   case Stmt::AsTypeExprClass:
   case Stmt::AtomicExprClass:


### PR DESCRIPTION
## Overview

Implements a range-based cilk_for syntax supporting containers with random access iterators.

For example, this PR adds support for syntax on the form:

```cpp
vector<int> v;
cilk_for (auto x : v) {
    f(x);
}
```

Previously, you had to do:

```cpp
vector<int> v;
cilk_for (int i = 0; i < v.size(); i++) {
    f(v[i]);
}
```

## Implementation

We introduce a new AST type, `CilkForRangeStmt`, taking inspiration from both `CilkForStmt` and `CXXForRangeStmt`.

The `CilkForRangeStmt` internally stores a `CXXForRangeStmt`, and lets the `CXXForRangeStmt` handle the parsing of the for loop. It then outputs IR similar to a `CilkForStmt`. The loop control differs from what one might expect: instead of having the loop variable be an iterator going from `container.begin()` to `container.end()` as in a normal for range loop, we emit a loop index of type `difference_type` going from `0` to `container.end() - container.begin()`. This makes it possible for the Tapir loop pass to transform the loop into a divide and conquer.

## Testing

1. Diagnostics tested in `clang/test/Cilk/rangelooptest.cpp`.
2. Correct IR output tested in `clang/test/Cilk/cilkforrange-ir.cpp`.
3. Tested on the example files from https://github.com/arvid220u/llvmurop/tree/main/examples, involving simple examples including random access iterators and non-random access iterators.
4. Each example above has been compiled using `-fsanitize=cilk` (Cilksan), reporting 0 determinancy races.
5. Benchmarked on the microbenchmarks from https://github.com/arvid220u/llvmurop/tree/main/microbenchmarks, being 10% slower on `O0`, and having no observable difference on any higher optimization levels.