### PR TITLE
Fix crash for aggregate types

### DIFF
--- a/clang/lib/CodeGen/CGCilk.cpp
+++ b/clang/lib/CodeGen/CGCilk.cpp
@@ -970,7 +970,7 @@ CodeGenFunction::EmitCilkForRangeStmt(const CilkForRangeStmt &S,
 //    EmitStoreThroughLValue(LoopVarInitRV, LV, true);
 //    EmitAutoVarCleanups(LVEmission);
 //  }
-//  EmitStmt(S.getLoopVarStmt());
+  EmitStmt(ForRange.getLoopVarStmt());
 
   Builder.CreateBr(ForBody);
 
@@ -984,12 +984,12 @@ CodeGenFunction::EmitCilkForRangeStmt(const CilkForRangeStmt &S,
     // NO! Instead, always create a new lexical scope because we want to emit
     // the loop var stmt and then the body, so it doesn't matter if the
     // body is a compound statement or not.
-    LexicalScope BodyScope(*this, ForRange.getSourceRange());
+    RunCleanupsScope BodyScope(*this);
 
     SyncedScopeRAII SyncedScp(*this);
-//    if (isa<CompoundStmt>(ForRange.getBody()))
+    if (isa<CompoundStmt>(ForRange.getBody()))
       ScopeIsSynced = true;
-    EmitStmt(ForRange.getLoopVarStmt());
+//    EmitStmt(ForRange.getLoopVarStmt());
     EmitStmt(ForRange.getBody());
 
     if (HaveInsertPoint())

--- a/clang/lib/CodeGen/CGCilk.cpp
+++ b/clang/lib/CodeGen/CGCilk.cpp
@@ -986,9 +986,9 @@ CodeGenFunction::EmitCilkForRangeStmt(const CilkForRangeStmt &S,
     // body is a compound statement or not.
     LexicalScope BodyScope(*this, ForRange.getSourceRange());
 
-//    SyncedScopeRAII SyncedScp(*this);
+    SyncedScopeRAII SyncedScp(*this);
 //    if (isa<CompoundStmt>(ForRange.getBody()))
-//      ScopeIsSynced = true;
+      ScopeIsSynced = true;
     EmitStmt(ForRange.getLoopVarStmt());
     EmitStmt(ForRange.getBody());
 

--- a/clang/lib/CodeGen/CGCilk.cpp
+++ b/clang/lib/CodeGen/CGCilk.cpp
@@ -970,6 +970,8 @@ CodeGenFunction::EmitCilkForRangeStmt(const CilkForRangeStmt &S,
 //    EmitStoreThroughLValue(LoopVarInitRV, LV, true);
 //    EmitAutoVarCleanups(LVEmission);
 //  }
+  // TODO: create a cleanup scope here?
+  // TODO: performance problems when emitting everything here?
   EmitStmt(ForRange.getLoopVarStmt());
 
   Builder.CreateBr(ForBody);
@@ -981,14 +983,12 @@ CodeGenFunction::EmitCilkForRangeStmt(const CilkForRangeStmt &S,
   {
     // Create a separate cleanup scope for the body, in case it is not
     // a compound statement.
-    // NO! Instead, always create a new lexical scope because we want to emit
-    // the loop var stmt and then the body, so it doesn't matter if the
-    // body is a compound statement or not.
     RunCleanupsScope BodyScope(*this);
 
     SyncedScopeRAII SyncedScp(*this);
     if (isa<CompoundStmt>(ForRange.getBody()))
       ScopeIsSynced = true;
+    // TODO: why does the cleanup crash if we emit the loop var stmt here?
 //    EmitStmt(ForRange.getLoopVarStmt());
     EmitStmt(ForRange.getBody());
 

--- a/clang/lib/CodeGen/CGCilk.cpp
+++ b/clang/lib/CodeGen/CGCilk.cpp
@@ -882,8 +882,8 @@ CodeGenFunction::EmitCilkForRangeStmt(const CilkForRangeStmt &S,
   llvm::AllocaInst *OldEHSelectorSlot;
   Address OldNormalCleanupDest = Address::invalid();
 
-  const VarDecl *LoopVar = ForRange.getLoopVariable();
-  RValue LoopVarInitRV;
+//  const VarDecl *LoopVar = ForRange.getLoopVariable();
+//  RValue LoopVarInitRV;
   llvm::BasicBlock *DetachBlock;
   llvm::BasicBlock *ForBodyEntry;
   llvm::BasicBlock *ForBody;
@@ -916,9 +916,9 @@ CodeGenFunction::EmitCilkForRangeStmt(const CilkForRangeStmt &S,
 
     // Get the value of the loop variable initialization before we emit the
     // detach.
-    if (LoopVar) {
-      LoopVarInitRV = EmitAnyExprToTemp(LoopVar->getInit());
-    }
+//    if (LoopVar) {
+//      LoopVarInitRV = EmitAnyExprToTemp(LoopVar->getInit());
+//    }
 
     Detach =
         Builder.CreateDetach(ForBodyEntry, Continue.getBlock(), SyncRegion);
@@ -961,15 +961,16 @@ CodeGenFunction::EmitCilkForRangeStmt(const CilkForRangeStmt &S,
 
   // Inside the detached block, create the loop variable, setting its value to
   // the saved initialization value.
-  if (LoopVar) {
-    AutoVarEmission LVEmission = EmitAutoVarAlloca(*LoopVar);
-    QualType type = LoopVar->getType();
-    Address Loc = LVEmission.getObjectAddress(*this);
-    LValue LV = MakeAddrLValue(Loc, type);
-    LV.setNonGC(true);
-    EmitStoreThroughLValue(LoopVarInitRV, LV, true);
-    EmitAutoVarCleanups(LVEmission);
-  }
+//  if (LoopVar) {
+//    AutoVarEmission LVEmission = EmitAutoVarAlloca(*LoopVar);
+//    QualType type = LoopVar->getType();
+//    Address Loc = LVEmission.getObjectAddress(*this);
+//    LValue LV = MakeAddrLValue(Loc, type);
+//    LV.setNonGC(true);
+//    EmitStoreThroughLValue(LoopVarInitRV, LV, true);
+//    EmitAutoVarCleanups(LVEmission);
+//  }
+//  EmitStmt(S.getLoopVarStmt());
 
   Builder.CreateBr(ForBody);
 
@@ -985,6 +986,7 @@ CodeGenFunction::EmitCilkForRangeStmt(const CilkForRangeStmt &S,
     SyncedScopeRAII SyncedScp(*this);
     if (isa<CompoundStmt>(ForRange.getBody()))
       ScopeIsSynced = true;
+    EmitStmt(ForRange.getLoopVarStmt());
     EmitStmt(ForRange.getBody());
 
     if (HaveInsertPoint())

--- a/clang/lib/CodeGen/CGCilk.cpp
+++ b/clang/lib/CodeGen/CGCilk.cpp
@@ -981,11 +981,14 @@ CodeGenFunction::EmitCilkForRangeStmt(const CilkForRangeStmt &S,
   {
     // Create a separate cleanup scope for the body, in case it is not
     // a compound statement.
-    RunCleanupsScope BodyScope(*this);
+    // NO! Instead, always create a new lexical scope because we want to emit
+    // the loop var stmt and then the body, so it doesn't matter if the
+    // body is a compound statement or not.
+    LexicalScope BodyScope(*this, ForRange.getSourceRange());
 
-    SyncedScopeRAII SyncedScp(*this);
-    if (isa<CompoundStmt>(ForRange.getBody()))
-      ScopeIsSynced = true;
+//    SyncedScopeRAII SyncedScp(*this);
+//    if (isa<CompoundStmt>(ForRange.getBody()))
+//      ScopeIsSynced = true;
     EmitStmt(ForRange.getLoopVarStmt());
     EmitStmt(ForRange.getBody());
 


### PR DESCRIPTION
This seems to work, but is still kind of sketchy. 

1. What are cleanups and do we need to do cleanups in `body.entry` now? 
2. Will performance suffer when we move the loop var init code into `body.entry`, from the `detach`, potentially because of some sort of true sharing?