### PR TITLE
Fix crash for aggregate types

### DIFF
--- a/clang/include/clang/AST/StmtCilk.h
+++ b/clang/include/clang/AST/StmtCilk.h
@@ -93,12 +93,12 @@ public:
 /// This is stored as a FORRANGE stmt embedded inside a CILKFORRANGE with some
 /// other necessary semantic components.
 class CilkForRangeStmt : public Stmt {
-  enum { FORRANGE, LOOPINDEX, LOOPINDEXSTMT, LIMIT, COND, INC, END };
+  enum { FORRANGE, LOOPINDEX, LOOPINDEXSTMT, LOCALLOOPINDEX, LIMIT, COND, INC, END };
   Stmt *SubExprs[END];
 
 public:
   CilkForRangeStmt(const ASTContext &C, CXXForRangeStmt *ForRange,
-                   VarDecl *LoopIndex, DeclStmt *Limit, Expr *Cond, Expr *Inc,
+                   VarDecl *LoopIndex, DeclStmt *LocalLoopIndex, DeclStmt *Limit, Expr *Cond, Expr *Inc,
                    DeclStmt *LoopIndexStmt);
 
   /// \brief Build an empty cilk for range statement.
@@ -122,6 +122,7 @@ public:
     return cast_or_null<DeclStmt>(SubExprs[LOOPINDEXSTMT]);
   }
   DeclStmt *getLimitStmt() { return cast_or_null<DeclStmt>(SubExprs[LIMIT]); }
+  DeclStmt *getLocalLoopIndexStmt() { return cast<DeclStmt>(SubExprs[LOCALLOOPINDEX]); }
 
   const Expr *getCond() const {
     return reinterpret_cast<Expr *>(SubExprs[COND]);
@@ -133,6 +134,7 @@ public:
   const DeclStmt *getLimitStmt() const {
     return cast_or_null<DeclStmt>(SubExprs[LIMIT]);
   }
+  const DeclStmt *getLocalLoopIndexStmt() const { return cast<DeclStmt>(SubExprs[LOCALLOOPINDEX]); }
 
   SourceLocation getBeginLoc() const LLVM_READONLY;
   SourceLocation getEndLoc() const LLVM_READONLY;

--- a/clang/include/clang/AST/StmtCilk.h
+++ b/clang/include/clang/AST/StmtCilk.h
@@ -93,12 +93,22 @@ public:
 /// This is stored as a FORRANGE stmt embedded inside a CILKFORRANGE with some
 /// other necessary semantic components.
 class CilkForRangeStmt : public Stmt {
-  enum { FORRANGE, LOOPINDEX, LOOPINDEXSTMT, LOCALLOOPINDEX, LIMIT, COND, INC, END };
+  enum {
+    FORRANGE,
+    LOOPINDEX,
+    LOOPINDEXSTMT,
+    LOCALLOOPINDEX,
+    LIMIT,
+    COND,
+    INC,
+    END
+  };
   Stmt *SubExprs[END];
 
 public:
   CilkForRangeStmt(const ASTContext &C, CXXForRangeStmt *ForRange,
-                   VarDecl *LoopIndex, DeclStmt *LocalLoopIndex, DeclStmt *Limit, Expr *Cond, Expr *Inc,
+                   VarDecl *LoopIndex, DeclStmt *LocalLoopIndex,
+                   DeclStmt *Limit, Expr *Cond, Expr *Inc,
                    DeclStmt *LoopIndexStmt);
 
   /// \brief Build an empty cilk for range statement.
@@ -125,7 +135,9 @@ public:
     return cast_or_null<DeclStmt>(SubExprs[LOOPINDEXSTMT]);
   }
   DeclStmt *getLimitStmt() { return cast_or_null<DeclStmt>(SubExprs[LIMIT]); }
-  DeclStmt *getLocalLoopIndexStmt() { return cast<DeclStmt>(SubExprs[LOCALLOOPINDEX]); }
+  DeclStmt *getLocalLoopIndexStmt() {
+    return cast<DeclStmt>(SubExprs[LOCALLOOPINDEX]);
+  }
 
   const Expr *getCond() const {
     return reinterpret_cast<Expr *>(SubExprs[COND]);
@@ -137,7 +149,9 @@ public:
   const DeclStmt *getLimitStmt() const {
     return cast_or_null<DeclStmt>(SubExprs[LIMIT]);
   }
-  const DeclStmt *getLocalLoopIndexStmt() const { return cast<DeclStmt>(SubExprs[LOCALLOOPINDEX]); }
+  const DeclStmt *getLocalLoopIndexStmt() const {
+    return cast<DeclStmt>(SubExprs[LOCALLOOPINDEX]);
+  }
 
   SourceLocation getBeginLoc() const LLVM_READONLY;
   SourceLocation getEndLoc() const LLVM_READONLY;

--- a/clang/include/clang/AST/StmtCilk.h
+++ b/clang/include/clang/AST/StmtCilk.h
@@ -116,6 +116,9 @@ public:
   VarDecl *getLoopIndex() const;
   void setLoopIndex(const ASTContext &C, VarDecl *V);
 
+  VarDecl *getLocalLoopIndex();
+  const VarDecl *getLocalLoopIndex() const;
+
   Expr *getCond() { return reinterpret_cast<Expr *>(SubExprs[COND]); }
   Expr *getInc() { return reinterpret_cast<Expr *>(SubExprs[INC]); }
   DeclStmt *getLoopIndexStmt() {

--- a/clang/lib/AST/StmtCXX.cpp
+++ b/clang/lib/AST/StmtCXX.cpp
@@ -130,8 +130,8 @@ CoroutineBodyStmt::CoroutineBodyStmt(CoroutineBodyStmt::CtorArgs const &Args)
 /// Constructor for the CilkForRangeStmt
 CilkForRangeStmt::CilkForRangeStmt(const ASTContext &C,
                                    CXXForRangeStmt *ForRange,
-                                   VarDecl *LoopIndex, DeclStmt *LocalLoopIndex, DeclStmt *Limit,
-                                   Expr *Cond, Expr *Inc,
+                                   VarDecl *LoopIndex, DeclStmt *LocalLoopIndex,
+                                   DeclStmt *Limit, Expr *Cond, Expr *Inc,
                                    DeclStmt *LoopIndexStmt)
     : Stmt(CilkForRangeStmtClass) {
   SubExprs[FORRANGE] = ForRange;

--- a/clang/lib/AST/StmtCXX.cpp
+++ b/clang/lib/AST/StmtCXX.cpp
@@ -163,6 +163,16 @@ void CilkForRangeStmt::setLoopIndex(const ASTContext &C, VarDecl *V) {
       new (C) DeclStmt(DeclGroupRef(V), VarRange.getBegin(), VarRange.getEnd());
 }
 
+VarDecl *CilkForRangeStmt::getLocalLoopIndex() {
+  Decl *LV = cast<DeclStmt>(getLocalLoopIndexStmt())->getSingleDecl();
+  assert(LV && "No local loop index in CilkForRangeStmt");
+  return cast<VarDecl>(LV);
+}
+
+const VarDecl *CilkForRangeStmt::getLocalLoopIndex() const {
+  return const_cast<CilkForRangeStmt *>(this)->getLocalLoopIndex();
+}
+
 /// returns the FORRANGE stmt embedded in the CilkForRange. (May be null.)
 CXXForRangeStmt *CilkForRangeStmt::getCXXForRangeStmt() const {
   return cast_or_null<CXXForRangeStmt>(SubExprs[FORRANGE]);

--- a/clang/lib/AST/StmtCXX.cpp
+++ b/clang/lib/AST/StmtCXX.cpp
@@ -130,12 +130,13 @@ CoroutineBodyStmt::CoroutineBodyStmt(CoroutineBodyStmt::CtorArgs const &Args)
 /// Constructor for the CilkForRangeStmt
 CilkForRangeStmt::CilkForRangeStmt(const ASTContext &C,
                                    CXXForRangeStmt *ForRange,
-                                   VarDecl *LoopIndex, DeclStmt *Limit,
+                                   VarDecl *LoopIndex, DeclStmt *LocalLoopIndex, DeclStmt *Limit,
                                    Expr *Cond, Expr *Inc,
                                    DeclStmt *LoopIndexStmt)
     : Stmt(CilkForRangeStmtClass) {
   SubExprs[FORRANGE] = ForRange;
   setLoopIndex(C, LoopIndex);
+  SubExprs[LOCALLOOPINDEX] = LocalLoopIndex;
   SubExprs[COND] = Cond;
   SubExprs[INC] = Inc;
   SubExprs[LOOPINDEXSTMT] = LoopIndexStmt;

--- a/clang/lib/CodeGen/CGCilk.cpp
+++ b/clang/lib/CodeGen/CGCilk.cpp
@@ -970,7 +970,7 @@ CodeGenFunction::EmitCilkForRangeStmt(const CilkForRangeStmt &S,
 //    EmitStoreThroughLValue(LoopVarInitRV, LV, true);
 //    EmitAutoVarCleanups(LVEmission);
 //  }
-//  EmitStmt(S.getLoopVarStmt());
+  EmitStmt(ForRange.getLoopVarStmt());
 
   Builder.CreateBr(ForBody);
 
@@ -984,12 +984,12 @@ CodeGenFunction::EmitCilkForRangeStmt(const CilkForRangeStmt &S,
     // NO! Instead, always create a new lexical scope because we want to emit
     // the loop var stmt and then the body, so it doesn't matter if the
     // body is a compound statement or not.
-    LexicalScope BodyScope(*this, ForRange.getSourceRange());
+    RunCleanupsScope BodyScope(*this);
 
     SyncedScopeRAII SyncedScp(*this);
-//    if (isa<CompoundStmt>(ForRange.getBody()))
+    if (isa<CompoundStmt>(ForRange.getBody()))
       ScopeIsSynced = true;
-    EmitStmt(ForRange.getLoopVarStmt());
+//    EmitStmt(ForRange.getLoopVarStmt());
     EmitStmt(ForRange.getBody());
 
     if (HaveInsertPoint())

--- a/clang/lib/CodeGen/CGCilk.cpp
+++ b/clang/lib/CodeGen/CGCilk.cpp
@@ -986,9 +986,9 @@ CodeGenFunction::EmitCilkForRangeStmt(const CilkForRangeStmt &S,
     // body is a compound statement or not.
     LexicalScope BodyScope(*this, ForRange.getSourceRange());
 
-//    SyncedScopeRAII SyncedScp(*this);
+    SyncedScopeRAII SyncedScp(*this);
 //    if (isa<CompoundStmt>(ForRange.getBody()))
-//      ScopeIsSynced = true;
+      ScopeIsSynced = true;
     EmitStmt(ForRange.getLoopVarStmt());
     EmitStmt(ForRange.getBody());
 

--- a/clang/lib/CodeGen/CGCilk.cpp
+++ b/clang/lib/CodeGen/CGCilk.cpp
@@ -970,6 +970,8 @@ CodeGenFunction::EmitCilkForRangeStmt(const CilkForRangeStmt &S,
 //    EmitStoreThroughLValue(LoopVarInitRV, LV, true);
 //    EmitAutoVarCleanups(LVEmission);
 //  }
+  // TODO: create a cleanup scope here?
+  // TODO: performance problems when emitting everything here?
   EmitStmt(ForRange.getLoopVarStmt());
 
   Builder.CreateBr(ForBody);
@@ -981,14 +983,12 @@ CodeGenFunction::EmitCilkForRangeStmt(const CilkForRangeStmt &S,
   {
     // Create a separate cleanup scope for the body, in case it is not
     // a compound statement.
-    // NO! Instead, always create a new lexical scope because we want to emit
-    // the loop var stmt and then the body, so it doesn't matter if the
-    // body is a compound statement or not.
     RunCleanupsScope BodyScope(*this);
 
     SyncedScopeRAII SyncedScp(*this);
     if (isa<CompoundStmt>(ForRange.getBody()))
       ScopeIsSynced = true;
+    // TODO: why does the cleanup crash if we emit the loop var stmt here?
 //    EmitStmt(ForRange.getLoopVarStmt());
     EmitStmt(ForRange.getBody());
 

--- a/clang/lib/CodeGen/CGCilk.cpp
+++ b/clang/lib/CodeGen/CGCilk.cpp
@@ -986,8 +986,6 @@ CodeGenFunction::EmitCilkForRangeStmt(const CilkForRangeStmt &S,
     SyncedScopeRAII SyncedScp(*this);
     if (isa<CompoundStmt>(ForRange.getBody()))
       ScopeIsSynced = true;
-    // TODO: why does the cleanup crash if we emit the loop var stmt here?
-//    EmitStmt(ForRange.getLoopVarStmt());
     EmitStmt(ForRange.getBody());
 
     if (HaveInsertPoint())

--- a/clang/lib/CodeGen/CGCilk.cpp
+++ b/clang/lib/CodeGen/CGCilk.cpp
@@ -882,8 +882,8 @@ CodeGenFunction::EmitCilkForRangeStmt(const CilkForRangeStmt &S,
   llvm::AllocaInst *OldEHSelectorSlot;
   Address OldNormalCleanupDest = Address::invalid();
 
-  const VarDecl *LoopVar = ForRange.getLoopVariable();
-  RValue LoopVarInitRV;
+//  const VarDecl *LoopVar = ForRange.getLoopVariable();
+//  RValue LoopVarInitRV;
   llvm::BasicBlock *DetachBlock;
   llvm::BasicBlock *ForBodyEntry;
   llvm::BasicBlock *ForBody;
@@ -916,9 +916,9 @@ CodeGenFunction::EmitCilkForRangeStmt(const CilkForRangeStmt &S,
 
     // Get the value of the loop variable initialization before we emit the
     // detach.
-    if (LoopVar) {
-      LoopVarInitRV = EmitAnyExprToTemp(LoopVar->getInit());
-    }
+//    if (LoopVar) {
+//      LoopVarInitRV = EmitAnyExprToTemp(LoopVar->getInit());
+//    }
 
     Detach =
         Builder.CreateDetach(ForBodyEntry, Continue.getBlock(), SyncRegion);
@@ -961,15 +961,16 @@ CodeGenFunction::EmitCilkForRangeStmt(const CilkForRangeStmt &S,
 
   // Inside the detached block, create the loop variable, setting its value to
   // the saved initialization value.
-  if (LoopVar) {
-    AutoVarEmission LVEmission = EmitAutoVarAlloca(*LoopVar);
-    QualType type = LoopVar->getType();
-    Address Loc = LVEmission.getObjectAddress(*this);
-    LValue LV = MakeAddrLValue(Loc, type);
-    LV.setNonGC(true);
-    EmitStoreThroughLValue(LoopVarInitRV, LV, true);
-    EmitAutoVarCleanups(LVEmission);
-  }
+//  if (LoopVar) {
+//    AutoVarEmission LVEmission = EmitAutoVarAlloca(*LoopVar);
+//    QualType type = LoopVar->getType();
+//    Address Loc = LVEmission.getObjectAddress(*this);
+//    LValue LV = MakeAddrLValue(Loc, type);
+//    LV.setNonGC(true);
+//    EmitStoreThroughLValue(LoopVarInitRV, LV, true);
+//    EmitAutoVarCleanups(LVEmission);
+//  }
+//  EmitStmt(S.getLoopVarStmt());
 
   Builder.CreateBr(ForBody);
 
@@ -985,6 +986,7 @@ CodeGenFunction::EmitCilkForRangeStmt(const CilkForRangeStmt &S,
     SyncedScopeRAII SyncedScp(*this);
     if (isa<CompoundStmt>(ForRange.getBody()))
       ScopeIsSynced = true;
+    EmitStmt(ForRange.getLoopVarStmt());
     EmitStmt(ForRange.getBody());
 
     if (HaveInsertPoint())

--- a/clang/lib/CodeGen/CGCilk.cpp
+++ b/clang/lib/CodeGen/CGCilk.cpp
@@ -981,11 +981,14 @@ CodeGenFunction::EmitCilkForRangeStmt(const CilkForRangeStmt &S,
   {
     // Create a separate cleanup scope for the body, in case it is not
     // a compound statement.
-    RunCleanupsScope BodyScope(*this);
+    // NO! Instead, always create a new lexical scope because we want to emit
+    // the loop var stmt and then the body, so it doesn't matter if the
+    // body is a compound statement or not.
+    LexicalScope BodyScope(*this, ForRange.getSourceRange());
 
-    SyncedScopeRAII SyncedScp(*this);
-    if (isa<CompoundStmt>(ForRange.getBody()))
-      ScopeIsSynced = true;
+//    SyncedScopeRAII SyncedScp(*this);
+//    if (isa<CompoundStmt>(ForRange.getBody()))
+//      ScopeIsSynced = true;
     EmitStmt(ForRange.getLoopVarStmt());
     EmitStmt(ForRange.getBody());
 

--- a/clang/lib/Sema/SemaStmt.cpp
+++ b/clang/lib/Sema/SemaStmt.cpp
@@ -3517,8 +3517,8 @@ StmtResult Sema::FinishCilkForRangeStmt(Stmt *S, Stmt *B) {
   ExprResult BeginRef = BuildDeclRefExpr(BeginVar, BeginRefNonRefType,
                                          VK_LValue, CXXForRange->getColonLoc());
 
-//  VarDecl *LoopIndex = CilkForRange->getLocalLoopIndex();
-  VarDecl *LoopIndex = CilkForRange->getLoopIndex();
+  VarDecl *LoopIndex = CilkForRange->getLocalLoopIndex();
+//  VarDecl *LoopIndex = CilkForRange->getLoopIndex();
   QualType LoopIndexType = LoopIndex->getType();
   const QualType LoopIndexRefNonRefType = LoopIndexType.getNonReferenceType();
   ExprResult LoopIndexRef = BuildDeclRefExpr(

--- a/clang/lib/Sema/SemaStmt.cpp
+++ b/clang/lib/Sema/SemaStmt.cpp
@@ -3518,7 +3518,6 @@ StmtResult Sema::FinishCilkForRangeStmt(Stmt *S, Stmt *B) {
                                          VK_LValue, CXXForRange->getColonLoc());
 
   VarDecl *LoopIndex = CilkForRange->getLocalLoopIndex();
-//  VarDecl *LoopIndex = CilkForRange->getLoopIndex();
   QualType LoopIndexType = LoopIndex->getType();
   const QualType LoopIndexRefNonRefType = LoopIndexType.getNonReferenceType();
   ExprResult LoopIndexRef = BuildDeclRefExpr(
@@ -3613,7 +3612,6 @@ StmtResult Sema::BuildCilkForRangeStmt(CXXForRangeStmt *ForRange) {
   if (LoopIndexStmt.isInvalid())
     return StmtError();
 
-
   ExprResult LimitRef =
       BuildDeclRefExpr(Limit, Limit->getType(), VK_LValue, RangeLoc);
   ExprResult LoopIndexRef =
@@ -3628,13 +3626,14 @@ StmtResult Sema::BuildCilkForRangeStmt(CXXForRangeStmt *ForRange) {
       BuildForRangeVarDecl(*this, RangeLoc, LimitExpr.get()->getType(),
                            std::string("__local_loopindex"));
   AddInitializerToDecl(LocalLoopIndex, LoopIndexRef.get(),
-      /*DirectInit=*/false);
+                       /*DirectInit=*/false);
   FinalizeDeclaration(LocalLoopIndex);
   CurContext->addHiddenDecl(LocalLoopIndex);
 
-  DeclGroupPtrTy LocalLoopIndexGroup =
-      BuildDeclaratorGroup(MutableArrayRef<Decl *>((Decl **)&LocalLoopIndex, 1));
-  StmtResult LocalLoopIndexStmt = ActOnDeclStmt(LocalLoopIndexGroup, RangeLoc, RangeLoc);
+  DeclGroupPtrTy LocalLoopIndexGroup = BuildDeclaratorGroup(
+      MutableArrayRef<Decl *>((Decl **)&LocalLoopIndex, 1));
+  StmtResult LocalLoopIndexStmt =
+      ActOnDeclStmt(LocalLoopIndexGroup, RangeLoc, RangeLoc);
   if (LocalLoopIndexStmt.isInvalid())
     return StmtError();
 
@@ -3647,8 +3646,9 @@ StmtResult Sema::BuildCilkForRangeStmt(CXXForRangeStmt *ForRange) {
     return StmtError();
 
   return new (Context) CilkForRangeStmt(
-      Context, ForRange, LoopIndex, cast<DeclStmt>(LocalLoopIndexStmt.get()), cast<DeclStmt>(LimitStmt.get()), Cond.get(),
-      NewInc.get(), cast<DeclStmt>(LoopIndexStmt.get()));
+      Context, ForRange, LoopIndex, cast<DeclStmt>(LocalLoopIndexStmt.get()),
+      cast<DeclStmt>(LimitStmt.get()), Cond.get(), NewInc.get(),
+      cast<DeclStmt>(LoopIndexStmt.get()));
 }
 
 StmtResult


### PR DESCRIPTION
Adds support for iteration over containers containing aggregate types.

That is,
```
vector<pair<int,int>> v;
cilk_for (auto x : v) {}
```
now works as expected, instead of, as before, crashing the compiler.